### PR TITLE
Implement temporary appendTxBatch format

### DIFF
--- a/src/specular/stages/batcher_transactions.rs
+++ b/src/specular/stages/batcher_transactions.rs
@@ -12,9 +12,9 @@ use std::collections::VecDeque;
 use crate::derive::stages::batcher_transactions::BatcherTransactionMessage;
 use crate::derive::PurgeableIterator;
 
-type AppendTxBatchInput = (U256, Bytes);
+type AppendTxBatchInput = Bytes;
 const APPEND_TX_BATCH_ABI_STR: &str = r#"[
-    function appendTxBatch(uint256 txBatchVersion,bytes calldata txBatch) external
+    function appendTxBatch(bytes calldata txBatchData) external
 ]"#;
 static APPEND_TX_BATCH_ABI: Lazy<BaseContract> = Lazy::new(|| {
     BaseContract::from(parse_abi_str(APPEND_TX_BATCH_ABI_STR).expect("abi must be valid"))
@@ -80,7 +80,7 @@ impl SpecularBatcherTransactions {
 pub struct SpecularBatcherTransaction {
     /// The block number of the L1 block that included this transaction.
     pub l1_inclusion_block: u64,
-    pub version: u64,
+    pub version: u8,
     pub tx_batch: Bytes,
 }
 
@@ -88,19 +88,15 @@ impl SpecularBatcherTransaction {
     /// Create a new batcher transaction from raw transaction data.
     /// Only `appendTxBatch` calls are considered valid.
     pub fn new(l1_inclusion_block: u64, data: &[u8]) -> Result<Self> {
-        if data.len() < 4 {
-            eyre::bail!("invalid transaction data");
-        }
-        if data[..4] != *APPEND_TX_BATCH_SELECTOR {
-            eyre::bail!("not appendTxBatch call");
-        }
-
-        let (tx_batch_version, tx_batch): AppendTxBatchInput =
-            APPEND_TX_BATCH_ABI.decode("appendTxBatch", data)?;
+        let tx_batch: AppendTxBatchInput =
+            APPEND_TX_BATCH_ABI.decode_with_selector(*APPEND_TX_BATCH_SELECTOR, data)?;
+        
+        let version = tx_batch.0[0];
+        let tx_batch = tx_batch.0.slice(1..).into();
 
         Ok(Self {
             l1_inclusion_block,
-            version: tx_batch_version.as_u64(),
+            version,
             tx_batch,
         })
     }

--- a/src/specular/stages/batcher_transactions.rs
+++ b/src/specular/stages/batcher_transactions.rs
@@ -4,7 +4,7 @@ use ethers::{
     abi::parse_abi_str,
     contract::Lazy,
     prelude::BaseContract,
-    types::{Bytes, Selector, U256},
+    types::{Bytes, Selector},
 };
 use eyre::Result;
 use std::collections::VecDeque;
@@ -90,7 +90,7 @@ impl SpecularBatcherTransaction {
     pub fn new(l1_inclusion_block: u64, data: &[u8]) -> Result<Self> {
         let tx_batch: AppendTxBatchInput =
             APPEND_TX_BATCH_ABI.decode_with_selector(*APPEND_TX_BATCH_SELECTOR, data)?;
-        
+
         let version = tx_batch.0[0];
         let tx_batch = tx_batch.0.slice(1..).into();
 


### PR DESCRIPTION
# Core changes

- Implement temporary appendTxBatch format, which encode version inside `txBatchData`

# Notes

- This will be deprecated when new derivation pipeline is implemented