### PR TITLE
Introduce rollup config

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -89,7 +89,7 @@ impl Cli {
             "optimism-sepolia" => ChainConfig::optimism_sepolia(),
             "base" => ChainConfig::base(),
             "base-goerli" => ChainConfig::base_goerli(),
-            file if file.contains("specular") => ChainConfig::from_specular_json(file),
+            file if file.starts_with("sp_") => ChainConfig::from_specular_json(file),
             file if file.ends_with(".json") => ChainConfig::from_json(file),
             _ => panic!(
                 "Invalid network name. \\

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -1,10 +1,8 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::{env::current_dir, process};
 
 use clap::Parser;
 use dirs::home_dir;
-use ethers::types::Address;
 use eyre::Result;
 
 use magi::config::LocalSequencerConfig;
@@ -79,11 +77,6 @@ pub struct Cli {
 pub struct LocalSequencerCli {
     #[clap(long = "sequencer")]
     enabled: bool,
-    #[clap(
-        long = "sequencer-suggested-fee-recipient",
-        default_value = "0x0000000000000000000000000000000000000000"
-    )]
-    suggested_fee_recipient: String,
     #[clap(long = "sequencer-max-safe-lag", default_value = "0")]
     max_safe_lag: u64,
 }
@@ -96,6 +89,7 @@ impl Cli {
             "optimism-sepolia" => ChainConfig::optimism_sepolia(),
             "base" => ChainConfig::base(),
             "base-goerli" => ChainConfig::base_goerli(),
+            file if file.contains("specular") => ChainConfig::from_specular_json(file),
             file if file.ends_with(".json") => ChainConfig::from_json(file),
             _ => panic!(
                 "Invalid network name. \\
@@ -153,7 +147,6 @@ impl From<LocalSequencerCli> for LocalSequencerConfig {
     fn from(value: LocalSequencerCli) -> Self {
         Self {
             enabled: value.enabled,
-            suggested_fee_recipient: Address::from_str(&value.suggested_fee_recipient).unwrap(),
             max_safe_lag: value.max_safe_lag,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,7 +64,6 @@ pub struct Config {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LocalSequencerConfig {
     pub enabled: bool,
-    pub suggested_fee_recipient: Address,
     pub max_safe_lag: u64,
 }
 

--- a/src/derive/stages/attributes.rs
+++ b/src/derive/stages/attributes.rs
@@ -79,7 +79,11 @@ impl Attributes {
         let seq_number = Some(self.sequence_number);
         let prev_randao = l1_info.block_info.mix_hash;
         let transactions = Some(self.derive_transactions(batch, l1_info));
-        let suggested_fee_recipient = SystemAccounts::default().fee_vault;
+        let suggested_fee_recipient = if self.config.chain.meta.enable_deposited_txs {
+            SystemAccounts::default().fee_vault
+        } else {
+            self.config.chain.system_config.batch_sender
+        };
 
         PayloadAttributes {
             timestamp,

--- a/src/driver/sequencing/mod.rs
+++ b/src/driver/sequencing/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 
 use super::engine_driver::EngineDriver;
 
+/// TODO: Support system config updates.
 #[async_trait(?Send)]
 pub trait SequencingSource<E: Engine> {
     /// Returns the next payload attributes to be built (if any) on top of

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -54,7 +54,7 @@ impl TryFrom<Block<Transaction>> for ExecutionPayload {
 
         Ok(ExecutionPayload {
             parent_hash: value.parent_hash,
-            fee_recipient: SystemAccounts::default().fee_vault,
+            fee_recipient: value.author.unwrap_or(SystemAccounts::default().fee_vault),
             state_root: value.state_root,
             receipts_root: value.receipts_root,
             logs_bloom: value.logs_bloom.unwrap().as_bytes().to_vec().into(),

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -1,0 +1,101 @@
+use ethers::types::{Address, H256, U256};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    common::{BlockInfo, Epoch},
+    config::{ChainConfig, ProtocolMetaConfig, SystemConfig},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalChainConfig {
+    genesis: ExternalGenesisInfo,
+    block_time: u64,
+    max_sequencer_drift: u64,
+    seq_window_size: u64,
+    l1_chain_id: u64,
+    l2_chain_id: u64,
+    batch_inbox_address: Address,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalGenesisInfo {
+    l1: ChainGenesisInfo,
+    l2: ChainGenesisInfo,
+    l2_time: u64,
+    system_config: SystemConfigInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SystemConfigInfo {
+    #[serde(rename = "batcherAddr")]
+    batcher_addr: Address,
+    #[serde(rename = "gasLimit")]
+    gas_limit: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChainGenesisInfo {
+    hash: H256,
+    number: u64,
+}
+
+impl From<ExternalChainConfig> for ChainConfig {
+    fn from(external: ExternalChainConfig) -> Self {
+        Self {
+            network: "external".to_string(),
+            l1_chain_id: external.l1_chain_id,
+            l2_chain_id: external.l2_chain_id,
+            l1_start_epoch: Epoch {
+                hash: external.genesis.l1.hash,
+                number: external.genesis.l1.number,
+                timestamp: external.genesis.l2_time,
+            },
+            l2_genesis: BlockInfo {
+                hash: external.genesis.l2.hash,
+                number: external.genesis.l2.number,
+                parent_hash: H256::zero(),
+                timestamp: external.genesis.l2_time,
+            },
+            system_config: SystemConfig {
+                batch_sender: external.genesis.system_config.batcher_addr,
+                gas_limit: U256::from(external.genesis.system_config.gas_limit),
+                l1_fee_overhead: U256::from(0),       // not used
+                l1_fee_scalar: U256::from(0),         // not used
+                unsafe_block_signer: Address::zero(), // not used?
+            },
+            batch_inbox: external.batch_inbox_address,
+            deposit_contract: Address::zero(),         // not used
+            system_config_contract: Address::zero(),   // not used
+            max_channel_size: 0,                       // not used
+            channel_timeout: 0,                        // not used
+            seq_window_size: external.seq_window_size, // NOTE: not used in derivation, but used in `State`
+            max_seq_drift: external.max_sequencer_drift,
+            regolith_time: 0, // not used
+            blocktime: external.block_time,
+            l2_to_l1_message_passer: Address::zero(), // not used?
+            meta: ProtocolMetaConfig::specular(),
+        }
+    }
+}
+
+impl ChainConfig {
+    pub fn from_specular_json(path: &str) -> Self {
+        tracing::info!(
+            "loading external specular chain config from json at {}",
+            path
+        );
+        let file = std::fs::File::open(path).unwrap();
+        let external: ExternalChainConfig = serde_json::from_reader(file).unwrap();
+        external.into()
+    }
+}
+
+impl ProtocolMetaConfig {
+    pub fn specular() -> Self {
+        Self {
+            enable_config_updates: false,
+            enable_deposited_txs: false,
+            enable_full_derivation: false,
+        }
+    }
+}

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -39,6 +39,15 @@ struct ChainGenesisInfo {
     number: u64,
 }
 
+impl ChainConfig {
+    pub fn from_specular_json(path: &str) -> Self {
+        tracing::info!("loading external specular chain config from {}", path);
+        let file = std::fs::File::open(path).unwrap();
+        let external: ExternalChainConfig = serde_json::from_reader(file).unwrap();
+        external.into()
+    }
+}
+
 impl From<ExternalChainConfig> for ChainConfig {
     fn from(external: ExternalChainConfig) -> Self {
         Self {
@@ -75,18 +84,6 @@ impl From<ExternalChainConfig> for ChainConfig {
             l2_to_l1_message_passer: Address::zero(), // not used?
             meta: ProtocolMetaConfig::specular(),
         }
-    }
-}
-
-impl ChainConfig {
-    pub fn from_specular_json(path: &str) -> Self {
-        tracing::info!(
-            "loading external specular chain config from json at {}",
-            path
-        );
-        let file = std::fs::File::open(path).unwrap();
-        let external: ExternalChainConfig = serde_json::from_reader(file).unwrap();
-        external.into()
     }
 }
 

--- a/src/specular/mod.rs
+++ b/src/specular/mod.rs
@@ -1,2 +1,3 @@
+pub mod config;
 pub mod sequencing;
 pub mod stages;

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -8,13 +8,14 @@ pub struct Config {
     pub max_safe_lag: u64,
     pub max_seq_drift: u64,
     pub blocktime: u64,
-    pub suggested_fee_recipient: H160,
     pub system_config: SystemConfig,
 }
 
-/// Sequencing policy system configuration.
+/// Subset of system configuration required by sequencing policy.
+/// TODO: The system config may change over time; handle this.
 #[derive(Clone, Debug)]
 pub struct SystemConfig {
+    pub batch_sender: H160,
     pub gas_limit: u64,
 }
 
@@ -24,7 +25,6 @@ impl Config {
             max_safe_lag: config.local_sequencer.max_safe_lag,
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
-            suggested_fee_recipient: config.local_sequencer.suggested_fee_recipient,
             system_config: SystemConfig::new(&config.chain.system_config),
         }
     }
@@ -33,6 +33,7 @@ impl Config {
 impl SystemConfig {
     pub fn new(config: &config::SystemConfig) -> Self {
         Self {
+            batch_sender: config.batch_sender,
             gas_limit: config.gas_limit.as_u64(),
         }
     }

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -87,7 +87,7 @@ impl SequencingPolicy for AttributesBuilder {
             .await?;
         let timestamp = self.next_timestamp(parent_l2_block.timestamp);
         let prev_randao = next_randao(&next_origin);
-        let suggested_fee_recipient = self.config.suggested_fee_recipient;
+        let suggested_fee_recipient = self.config.system_config.batch_sender;
         let txs = create_top_of_block_transactions(&next_origin);
         let no_tx_pool = timestamp > self.config.max_seq_drift;
         let gas_limit = self.config.system_config.gas_limit;
@@ -137,6 +137,7 @@ mod tests {
     use crate::{common::BlockInfo, driver::sequencing::SequencingPolicy};
 
     use super::{config, unix_now, AttributesBuilder};
+    use ethers::abi::Address;
     use eyre::Result;
 
     #[test]
@@ -146,8 +147,10 @@ mod tests {
             blocktime: 2,
             max_seq_drift: 0, // anything
             max_safe_lag: 10,
-            suggested_fee_recipient: Default::default(), // anything
-            system_config: config::SystemConfig { gas_limit: 1 }, // anything
+            system_config: config::SystemConfig {
+                batch_sender: Address::zero(),
+                gas_limit: 1,
+            }, // anything
         };
         let attrs_builder = AttributesBuilder::new(config.clone());
         // Run test cases.


### PR DESCRIPTION
- Parse a `ChainConfig` from a specular-specific `rollup.json` config (currently just a strict subset of the optimism config)
- Use `system_config.batch_sender` as fee recipient for now