### PR TITLE
Unblock `advance` loop from sequencer block building

### DIFF
--- a/src/driver/sequencing/mod.rs
+++ b/src/driver/sequencing/mod.rs
@@ -47,6 +47,11 @@ impl<E: Engine, T: SequencingPolicy, U: JsonRpcClient> SequencingSource<E> for S
         state: &Arc<RwLock<State>>,
         engine_driver: &EngineDriver<E>,
     ) -> Result<Option<PayloadAttributes>> {
+        // Check if we're already building a payload.
+        if engine_driver.pending_id.is_some() {
+            return Ok(None);
+        }
+
         let parent_l2_block = &engine_driver.unsafe_head;
         let safe_l2_head = {
             let state = state.read().unwrap();


### PR DESCRIPTION
- Remove `sleep` from ` build_payload` in the sequencer path
- Save `sleep` future in `EngineDriver` to determine if block building is over or not

**Notes:**
- It is better not to use the future but a plain timestamp
- A better abstraction is to separate the sequencer path out of `EngineDriver`