### PR TITLE
L1 Oracle update & derivation pipeline change Pt. 1

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -146,7 +146,7 @@ impl From<Cli> for CliConfig {
 }
 
 impl LocalSequencerCli {
-    pub fn private_key(&self) -> Option<String> {
+    pub fn read_private_key(&self) -> Option<String> {
         let pk_file = self.pk_file.as_ref()?;
         match std::fs::read_to_string(pk_file) {
             Ok(content) => Some(content),
@@ -163,7 +163,7 @@ impl From<LocalSequencerCli> for LocalSequencerConfig {
         Self {
             enabled: value.enabled,
             max_safe_lag: value.max_safe_lag,
-            private_key: value.private_key(),
+            private_key: value.read_private_key(),
         }
     }
 }

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -163,7 +163,7 @@ impl From<LocalSequencerCli> for LocalSequencerConfig {
         Self {
             enabled: value.enabled,
             max_safe_lag: value.max_safe_lag,
-            private_key: value.private_key().expect("sequencer pk file is required"),
+            private_key: value.private_key(),
         }
     }
 }

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -79,6 +79,8 @@ pub struct LocalSequencerCli {
     enabled: bool,
     #[clap(long = "sequencer-max-safe-lag", default_value = "0")]
     max_safe_lag: u64,
+    #[clap(long = "sequencer-pk-file")]
+    pk_file: Option<PathBuf>,
 }
 
 impl Cli {
@@ -143,11 +145,25 @@ impl From<Cli> for CliConfig {
     }
 }
 
+impl LocalSequencerCli {
+    pub fn private_key(&self) -> Option<String> {
+        let pk_file = self.pk_file.as_ref()?;
+        match std::fs::read_to_string(pk_file) {
+            Ok(content) => Some(content),
+            Err(_) => {
+                tracing::error!(target: "magi", "Failed to read sequencer pk from file: {:?}", pk_file);
+                None
+            }
+        }
+    }
+}
+
 impl From<LocalSequencerCli> for LocalSequencerConfig {
     fn from(value: LocalSequencerCli) -> Self {
         Self {
             enabled: value.enabled,
             max_safe_lag: value.max_safe_lag,
+            private_key: value.private_key().expect("sequencer pk file is required"),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,7 +65,7 @@ pub struct Config {
 pub struct LocalSequencerConfig {
     pub enabled: bool,
     pub max_safe_lag: u64,
-    pub private_key: String,
+    pub private_key: Option<String>,
 }
 
 impl Config {
@@ -160,8 +160,6 @@ pub struct ChainConfig {
     pub l2_to_l1_message_passer: Address,
     /// Protocol meta configuration
     pub meta: ProtocolMetaConfig,
-    /// [specular] The L2-predeploy L1 oracle contract address
-    pub l1_oracle: Address,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,6 +167,8 @@ pub struct ProtocolMetaConfig {
     pub enable_config_updates: bool,
     pub enable_deposited_txs: bool,
     pub enable_full_derivation: bool,
+    /// Specular: The L2-predeploy L1 oracle contract address
+    pub l1_oracle: Address,
 }
 
 impl ProtocolMetaConfig {
@@ -177,6 +177,7 @@ impl ProtocolMetaConfig {
             enable_config_updates: true,
             enable_deposited_txs: true,
             enable_full_derivation: true,
+            l1_oracle: Address::zero(),
         }
     }
 }
@@ -286,7 +287,6 @@ impl ChainConfig {
             blocktime: 2,
             regolith_time: 0,
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
 
@@ -326,7 +326,6 @@ impl ChainConfig {
             regolith_time: 1679079600,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
     pub fn optimism_sepolia() -> Self {
@@ -365,7 +364,6 @@ impl ChainConfig {
             regolith_time: 0,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
 
@@ -403,7 +401,6 @@ impl ChainConfig {
             blocktime: 2,
             regolith_time: 0,
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
 
@@ -441,7 +438,6 @@ impl ChainConfig {
             regolith_time: 1683219600,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
 }
@@ -547,7 +543,6 @@ impl From<ExternalChainConfig> for ChainConfig {
             blocktime: external.block_time,
             l2_to_l1_message_passer: addr("0x4200000000000000000000000000000000000016"),
             meta: ProtocolMetaConfig::optimism(),
-            l1_oracle: Address::zero(),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,6 +65,7 @@ pub struct Config {
 pub struct LocalSequencerConfig {
     pub enabled: bool,
     pub max_safe_lag: u64,
+    pub private_key: String,
 }
 
 impl Config {
@@ -159,6 +160,8 @@ pub struct ChainConfig {
     pub l2_to_l1_message_passer: Address,
     /// Protocol meta configuration
     pub meta: ProtocolMetaConfig,
+    /// [specular] The L2-predeploy L1 oracle contract address
+    pub l1_oracle: Address,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -283,6 +286,7 @@ impl ChainConfig {
             blocktime: 2,
             regolith_time: 0,
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
 
@@ -322,6 +326,7 @@ impl ChainConfig {
             regolith_time: 1679079600,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
     pub fn optimism_sepolia() -> Self {
@@ -360,6 +365,7 @@ impl ChainConfig {
             regolith_time: 0,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
 
@@ -397,6 +403,7 @@ impl ChainConfig {
             blocktime: 2,
             regolith_time: 0,
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
 
@@ -434,6 +441,7 @@ impl ChainConfig {
             regolith_time: 1683219600,
             blocktime: 2,
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
 }
@@ -539,6 +547,7 @@ impl From<ExternalChainConfig> for ChainConfig {
             blocktime: external.block_time,
             l2_to_l1_message_passer: Address::zero(),
             meta: ProtocolMetaConfig::optimism(),
+            l1_oracle: Address::zero(),
         }
     }
 }

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -86,6 +86,8 @@ pub struct L1BlockInfo {
     pub base_fee: U256,
     /// L1 mix hash (prevrandao)
     pub mix_hash: H256,
+    /// L1 state root
+    pub state_root: H256,
 }
 
 /// Watcher actually ingests the L1 blocks. Should be run in another
@@ -474,6 +476,7 @@ impl L1Info {
                 .base_fee_per_gas
                 .ok_or(eyre::eyre!("block is pre london"))?,
             mix_hash: block.mix_hash.ok_or(eyre::eyre!("block not included"))?,
+            state_root: block.state_root,
         };
 
         let batcher_transactions =

--- a/src/l1/utils.rs
+++ b/src/l1/utils.rs
@@ -31,5 +31,6 @@ fn try_create_l1_block_info(block: &Block<H256>) -> Result<L1BlockInfo> {
             .base_fee_per_gas
             .ok_or(eyre::eyre!("base fee missing"))?,
         mix_hash: block.mix_hash.ok_or(eyre::eyre!("mix_hash missing"))?,
+        state_root: block.state_root,
     })
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -194,7 +194,7 @@ impl Runner {
             (true, false) => {
                 let cfg = specular::sequencing::config::Config::new(&self.config);
                 let l2_provider = Provider::try_from(&self.config.l2_rpc_url)?;
-                let policy = specular::sequencing::AttributesBuilder::new(cfg, Some(l2_provider));
+                let policy = specular::sequencing::AttributesBuilder::new(cfg, l2_provider);
                 let l1_provider = Provider::try_from(self.config.l1_rpc_url.clone())?;
                 let sequencing_src = sequencing::Source::new(policy, l1_provider);
                 self.start_driver_for_real(Some(sequencing_src)).await?

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -193,9 +193,10 @@ impl Runner {
             (true, true) => panic!("not currently supported"),
             (true, false) => {
                 let cfg = specular::sequencing::config::Config::new(&self.config);
-                let policy = specular::sequencing::AttributesBuilder::new(cfg);
-                let provider = Provider::try_from(self.config.l1_rpc_url.clone())?;
-                let sequencing_src = sequencing::Source::new(policy, provider);
+                let l2_provider = Provider::try_from(&self.config.l2_rpc_url)?;
+                let policy = specular::sequencing::AttributesBuilder::new(cfg, l2_provider);
+                let l1_provider = Provider::try_from(self.config.l1_rpc_url.clone())?;
+                let sequencing_src = sequencing::Source::new(policy, l1_provider);
                 self.start_driver_for_real(Some(sequencing_src)).await?
             }
             _ => self.start_driver_for_real(sequencing::none()).await?,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -194,7 +194,7 @@ impl Runner {
             (true, false) => {
                 let cfg = specular::sequencing::config::Config::new(&self.config);
                 let l2_provider = Provider::try_from(&self.config.l2_rpc_url)?;
-                let policy = specular::sequencing::AttributesBuilder::new(cfg, l2_provider);
+                let policy = specular::sequencing::AttributesBuilder::new(cfg, Some(l2_provider));
                 let l1_provider = Provider::try_from(self.config.l1_rpc_url.clone())?;
                 let sequencing_src = sequencing::Source::new(policy, l1_provider);
                 self.start_driver_for_real(Some(sequencing_src)).await?

--- a/src/specular/common/mod.rs
+++ b/src/specular/common/mod.rs
@@ -1,0 +1,36 @@
+use ethers::{
+    abi::parse_abi_str,
+    contract::Lazy,
+    prelude::BaseContract,
+    types::{Bytes, Selector, H256, U256},
+};
+
+pub type AppendTxBatchInput = Bytes;
+pub const APPEND_TX_BATCH_ABI_STR: &str = r#"[
+    function appendTxBatch(bytes calldata txBatchData) external
+]"#;
+pub static APPEND_TX_BATCH_ABI: Lazy<BaseContract> = Lazy::new(|| {
+    BaseContract::from(parse_abi_str(APPEND_TX_BATCH_ABI_STR).expect("abi must be valid"))
+});
+pub static APPEND_TX_BATCH_SELECTOR: Lazy<Selector> = Lazy::new(|| {
+    APPEND_TX_BATCH_ABI
+        .abi()
+        .function("appendTxBatch")
+        .expect("function must be present")
+        .short_signature()
+});
+
+pub type SetL1OracleValuesInput = (U256, U256, U256, H256, H256);
+pub const SET_L1_ORACLE_VALUES_ABI_STR: &str = r#"[
+    function setL1OracleValues(uint256 _number,uint256 _timestamp,uint256 _baseFee,bytes32 _hash,bytes32 _stateRoot) external
+]"#;
+pub static SET_L1_ORACLE_VALUES_ABI: Lazy<BaseContract> = Lazy::new(|| {
+    BaseContract::from(parse_abi_str(SET_L1_ORACLE_VALUES_ABI_STR).expect("abi must be valid"))
+});
+pub static SET_L1_ORACLE_VALUES_SELECTOR: Lazy<Selector> = Lazy::new(|| {
+    SET_L1_ORACLE_VALUES_ABI
+        .abi()
+        .function("setL1OracleValues")
+        .expect("function must be present")
+        .short_signature()
+});

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -83,18 +83,18 @@ impl From<ExternalChainConfig> for ChainConfig {
             regolith_time: 0, // not used
             blocktime: external.block_time,
             l2_to_l1_message_passer: Address::zero(), // not used?
-            meta: ProtocolMetaConfig::specular(),
-            l1_oracle: external.l1_oracle_address,
+            meta: ProtocolMetaConfig::specular(external.l1_oracle_address),
         }
     }
 }
 
 impl ProtocolMetaConfig {
-    pub fn specular() -> Self {
+    pub fn specular(l1_oracle: Address) -> Self {
         Self {
             enable_config_updates: false,
             enable_deposited_txs: false,
             enable_full_derivation: false,
+            l1_oracle,
         }
     }
 }

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -15,6 +15,7 @@ struct ExternalChainConfig {
     l1_chain_id: u64,
     l2_chain_id: u64,
     batch_inbox_address: Address,
+    l1_oracle_address: Address,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,6 +84,7 @@ impl From<ExternalChainConfig> for ChainConfig {
             blocktime: external.block_time,
             l2_to_l1_message_passer: Address::zero(), // not used?
             meta: ProtocolMetaConfig::specular(),
+            l1_oracle: external.l1_oracle_address,
         }
     }
 }

--- a/src/specular/mod.rs
+++ b/src/specular/mod.rs
@@ -1,3 +1,4 @@
+pub mod common;
 pub mod config;
 pub mod sequencing;
 pub mod stages;

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -1,6 +1,6 @@
 use ethers::types::H160;
 
-use crate::config;
+use crate::config::{Config as MagiConfig, SystemConfig as MagiSystemConfig};
 
 /// Sequencing policy configuration.
 #[derive(Clone, Debug)]
@@ -22,20 +22,24 @@ pub struct SystemConfig {
 }
 
 impl Config {
-    pub fn new(config: &config::Config) -> Self {
+    pub fn new(config: &MagiConfig) -> Self {
         Self {
             max_safe_lag: config.local_sequencer.max_safe_lag,
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
             system_config: SystemConfig::new(&config.chain.system_config),
-            l1_oracle_address: config.chain.l1_oracle,
-            sequencer_private_key: config.local_sequencer.private_key.clone(),
+            l1_oracle_address: config.chain.meta.l1_oracle,
+            sequencer_private_key: config
+                .local_sequencer
+                .private_key
+                .clone()
+                .expect("sequencer pk file is required"),
         }
     }
 }
 
 impl SystemConfig {
-    pub fn new(config: &config::SystemConfig) -> Self {
+    pub fn new(config: &MagiSystemConfig) -> Self {
         Self {
             batch_sender: config.batch_sender,
             gas_limit: config.gas_limit.as_u64(),

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub max_seq_drift: u64,
     pub blocktime: u64,
     pub system_config: SystemConfig,
+    pub l1_oracle: H160,
+    pub sequencer_private_key: String,
 }
 
 /// Subset of system configuration required by sequencing policy.
@@ -26,6 +28,8 @@ impl Config {
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
             system_config: SystemConfig::new(&config.chain.system_config),
+            l1_oracle: config.chain.l1_oracle,
+            sequencer_private_key: config.local_sequencer.private_key.clone(),
         }
     }
 }

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
     pub max_seq_drift: u64,
     pub blocktime: u64,
     pub system_config: SystemConfig,
-    pub l1_oracle: H160,
+    pub l1_oracle_address: H160,
     pub sequencer_private_key: String,
 }
 
@@ -28,7 +28,7 @@ impl Config {
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
             system_config: SystemConfig::new(&config.chain.system_config),
-            l1_oracle: config.chain.l1_oracle,
+            l1_oracle_address: config.chain.l1_oracle,
             sequencer_private_key: config.local_sequencer.private_key.clone(),
         }
     }

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -31,8 +31,7 @@ impl AttributesBuilder {
     pub fn new(config: config::Config, l2_provider: Option<Provider<Http>>) -> Self {
         let wallet = LocalWallet::try_from(config.sequencer_private_key.clone())
             .expect("invalid sequencer private key");
-        let client = 
-        l2_provider.map(|l2_provider| SignerMiddleware::new(l2_provider, wallet));
+        let client = l2_provider.map(|l2_provider| SignerMiddleware::new(l2_provider, wallet));
         Self { config, client }
     }
 
@@ -102,7 +101,10 @@ impl SequencingPolicy for AttributesBuilder {
         let timestamp = self.next_timestamp(parent_l2_block.timestamp);
         let prev_randao = next_randao(&next_origin);
         let suggested_fee_recipient = self.config.system_config.batch_sender;
-        let client = self.client.as_ref().ok_or(eyre::eyre!("client not initialized"))?;
+        let client = self
+            .client
+            .as_ref()
+            .ok_or(eyre::eyre!("client not initialized"))?;
         let txs = create_l1_oracle_update_transaction(
             &self.config,
             client,

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use ethers::{
     middleware::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
+    providers::Middleware,
     signers::{LocalWallet, Signer},
     types::{TransactionRequest, H256, U256, U64},
 };
@@ -22,16 +22,18 @@ use crate::specular::common::{
 
 pub mod config;
 
-pub struct AttributesBuilder {
+pub struct AttributesBuilder<M> {
     config: config::Config,
-    client: Option<SignerMiddleware<Provider<Http>, LocalWallet>>,
+    client: SignerMiddleware<M, LocalWallet>,
 }
 
-impl AttributesBuilder {
-    pub fn new(config: config::Config, l2_provider: Option<Provider<Http>>) -> Self {
+// TODO[zhe]: 'static works for Http provider and MockProvider, not sure if it works for all [Middleware]
+// TODO[zhe]: has to be 'static because o/w [Middleware::fill_transaction] will complain about lifetime
+impl<M: Middleware + 'static> AttributesBuilder<M> {
+    pub fn new(config: config::Config, l2_provider: M) -> Self {
         let wallet = LocalWallet::try_from(config.sequencer_private_key.clone())
             .expect("invalid sequencer private key");
-        let client = l2_provider.map(|l2_provider| SignerMiddleware::new(l2_provider, wallet));
+        let client = SignerMiddleware::new(l2_provider, wallet);
         Self { config, client }
     }
 
@@ -77,10 +79,51 @@ impl AttributesBuilder {
             }
         }
     }
+
+    // Creates the `L1Oracle::setL1OracleValues` transaction to include at the top of
+    // the next l2 block, which marks the start of an epoch.
+    async fn create_l1_oracle_update_transaction(
+        &self,
+        parent_l2_block: &BlockInfo,
+        parent_l1_epoch: &L1BlockInfo,
+        origin: &L1BlockInfo,
+    ) -> Result<Option<Vec<RawTransaction>>> {
+        if parent_l1_epoch.number == origin.number {
+            // Do not include the L1 oracle update tx if we are still in the same L1 epoch.
+            return Ok(None);
+        }
+        // Construct L1 oracle update transaction data
+        let set_l1_oracle_values_input: SetL1OracleValuesInput = (
+            U256::from(origin.number),
+            U256::from(origin.timestamp),
+            origin.base_fee,
+            origin.hash,
+            origin.state_root,
+        );
+        let input = SET_L1_ORACLE_VALUES_ABI
+            .encode_with_selector(*SET_L1_ORACLE_VALUES_SELECTOR, set_l1_oracle_values_input)
+            .expect("failed to encode setL1OracleValues input");
+        // Construct L1 oracle update transaction
+        let mut tx = TransactionRequest::new()
+            .to(self.config.l1_oracle_address)
+            .gas(150_000_000) // TODO[zhe]: consider to lower this number
+            .value(0)
+            .data(input)
+            .into();
+        let target_l2_block_number = parent_l2_block.number + 1;
+        // TODO[zhe]: here we let the provider to fill in the gas price
+        // TODO[zhe]: consider to make it constant?
+        self.client
+            .fill_transaction(&mut tx, Some(target_l2_block_number.into()))
+            .await?;
+        let signature = Signer::sign_transaction(self.client.signer(), &tx).await?;
+        let raw_tx = tx.rlp_signed(&signature);
+        Ok(Some(vec![RawTransaction(raw_tx.0.into())]))
+    }
 }
 
 #[async_trait]
-impl SequencingPolicy for AttributesBuilder {
+impl<M: Middleware + 'static> SequencingPolicy for AttributesBuilder<M> {
     /// Returns true iff:
     /// 1. `parent_l2_block` is within the max safe lag (i.e. the unsafe head isn't too far ahead of the safe head).
     /// 2. The next timestamp isn't in the future.
@@ -101,18 +144,9 @@ impl SequencingPolicy for AttributesBuilder {
         let timestamp = self.next_timestamp(parent_l2_block.timestamp);
         let prev_randao = next_randao(&next_origin);
         let suggested_fee_recipient = self.config.system_config.batch_sender;
-        let client = self
-            .client
-            .as_ref()
-            .ok_or(eyre::eyre!("client not initialized"))?;
-        let txs = create_l1_oracle_update_transaction(
-            &self.config,
-            client,
-            parent_l2_block,
-            parent_l1_epoch,
-            &next_origin,
-        )
-        .await?;
+        let txs = self
+            .create_l1_oracle_update_transaction(parent_l2_block, parent_l1_epoch, &next_origin)
+            .await?;
         let no_tx_pool = timestamp > self.config.max_seq_drift;
         let gas_limit = self.config.system_config.gas_limit;
         Ok(PayloadAttributes {
@@ -127,47 +161,6 @@ impl SequencingPolicy for AttributesBuilder {
             seq_number: None,
         })
     }
-}
-
-// Creates the `L1Oracle::setL1OracleValues` transaction to include at the top of
-// the next l2 block, which marks the start of an epoch.
-async fn create_l1_oracle_update_transaction(
-    config: &config::Config,
-    client: &SignerMiddleware<Provider<Http>, LocalWallet>,
-    parent_l2_block: &BlockInfo,
-    parent_l1_epoch: &L1BlockInfo,
-    origin: &L1BlockInfo,
-) -> Result<Option<Vec<RawTransaction>>> {
-    if parent_l1_epoch.number == origin.number {
-        // Do not include the L1 oracle update tx if we are still in the same L1 epoch.
-        return Ok(None);
-    }
-    // Construct L1 oracle update transaction data
-    let set_l1_oracle_values_input: SetL1OracleValuesInput = (
-        U256::from(origin.number),
-        U256::from(origin.timestamp),
-        origin.base_fee,
-        origin.hash,
-        origin.state_root,
-    );
-    let input = SET_L1_ORACLE_VALUES_ABI
-        .encode_with_selector(*SET_L1_ORACLE_VALUES_SELECTOR, set_l1_oracle_values_input)
-        .expect("failed to encode setL1OracleValues input");
-    // Construct L1 oracle update transaction
-    let mut tx = TransactionRequest::new()
-        .to(config.l1_oracle_address)
-        .gas(150_000_000) // TODO[zhe]: consider to lower this number
-        .value(0)
-        .data(input)
-        .into();
-    // TODO[zhe]: here we let the provider to fill in the gas price
-    // TODO[zhe]: consider to make it constant?
-    client
-        .fill_transaction(&mut tx, Some((parent_l2_block.number + 1).into()))
-        .await?;
-    let signature = client.signer().sign_transaction(&tx).await?;
-    let raw_tx = tx.rlp_signed(&signature);
-    Ok(Some(vec![RawTransaction(raw_tx.0.into())]))
 }
 
 /// Returns the next l2 block randao, reusing that of the `next_origin`.
@@ -196,7 +189,10 @@ mod tests {
     use crate::{common::BlockInfo, driver::sequencing::SequencingPolicy};
 
     use super::{config, unix_now, AttributesBuilder};
-    use ethers::abi::Address;
+    use ethers::{
+        abi::Address,
+        providers::{MockProvider, Provider},
+    };
     use eyre::Result;
     #[test]
     fn test_is_ready() -> Result<()> {
@@ -214,7 +210,9 @@ mod tests {
             sequencer_private_key:
                 "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".to_string(),
         };
-        let attrs_builder = AttributesBuilder::new(config.clone(), None);
+        let mock_client = MockProvider::default();
+        let provider: Provider<MockProvider> = Provider::new(mock_client);
+        let attrs_builder = AttributesBuilder::new(config.clone(), provider);
         // Run test cases.
         let cases = vec![(true, true), (true, false), (false, true), (false, false)];
         for case in cases.iter() {

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -32,10 +32,7 @@ impl AttributesBuilder {
         let wallet = LocalWallet::try_from(config.sequencer_private_key.clone())
             .expect("invalid sequencer private key");
         let client = SignerMiddleware::new(l2_provider, wallet);
-        Self {
-            config,
-            client,
-        }
+        Self { config, client }
     }
 
     /// Returns the next l2 block timestamp, given the `parent_block_timestamp`.
@@ -202,7 +199,7 @@ mod tests {
     #[test]
     fn test_is_ready() -> Result<()> {
         // Setup.
-        let config: config::Config = config::Config {
+        let config = config::Config {
             blocktime: 2,
             max_seq_drift: 0, // anything
             max_safe_lag: 10,

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -1,7 +1,12 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use ethers::types::{H256, U64};
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::{Http, Middleware, Provider},
+    signers::{LocalWallet, Signer},
+    types::{TransactionRequest, H256, U256, U64},
+};
 use eyre::Result;
 
 use crate::{
@@ -11,15 +16,26 @@ use crate::{
     l1::L1BlockInfo,
 };
 
+use crate::specular::common::{
+    SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR,
+};
+
 pub mod config;
 
 pub struct AttributesBuilder {
     config: config::Config,
+    client: SignerMiddleware<Provider<Http>, LocalWallet>,
 }
 
 impl AttributesBuilder {
-    pub fn new(config: config::Config) -> Self {
-        Self { config }
+    pub fn new(config: config::Config, l2_provider: Provider<Http>) -> Self {
+        let wallet = LocalWallet::try_from(config.sequencer_private_key.clone())
+            .expect("invalid sequencer private key");
+        let client = SignerMiddleware::new(l2_provider, wallet);
+        Self {
+            config,
+            client,
+        }
     }
 
     /// Returns the next l2 block timestamp, given the `parent_block_timestamp`.
@@ -88,16 +104,23 @@ impl SequencingPolicy for AttributesBuilder {
         let timestamp = self.next_timestamp(parent_l2_block.timestamp);
         let prev_randao = next_randao(&next_origin);
         let suggested_fee_recipient = self.config.system_config.batch_sender;
-        let txs = create_top_of_block_transactions(&next_origin);
+        let txs = create_l1_oracle_update_transaction(
+            &self.config,
+            &self.client,
+            parent_l2_block,
+            parent_l1_epoch,
+            &next_origin,
+        )
+        .await?;
         let no_tx_pool = timestamp > self.config.max_seq_drift;
         let gas_limit = self.config.system_config.gas_limit;
         Ok(PayloadAttributes {
-            timestamp: U64([timestamp]),
+            timestamp: U64::from(timestamp),
             prev_randao,
             suggested_fee_recipient,
-            transactions: Some(txs),
+            transactions: txs,
             no_tx_pool,
-            gas_limit: U64([gas_limit]),
+            gas_limit: U64::from(gas_limit),
             epoch: Some(create_epoch(next_origin)),
             l1_inclusion_block: None,
             seq_number: None,
@@ -107,8 +130,43 @@ impl SequencingPolicy for AttributesBuilder {
 
 // TODO: implement. requires l1 info tx. requires signer...
 // Creates the transaction(s) to include at the top of the next l2 block.
-fn create_top_of_block_transactions(_origin: &L1BlockInfo) -> Vec<RawTransaction> {
-    vec![]
+async fn create_l1_oracle_update_transaction(
+    config: &config::Config,
+    client: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    parent_l2_block: &BlockInfo,
+    parent_l1_epoch: &L1BlockInfo,
+    origin: &L1BlockInfo,
+) -> Result<Option<Vec<RawTransaction>>> {
+    if parent_l1_epoch.number == origin.number {
+        // Do not include the L1 oracle update tx if we are still in the same L1 epoch.
+        return Ok(None);
+    }
+    // Construct L1 oracle update transaction data
+    let set_l1_oracle_values_input: SetL1OracleValuesInput = (
+        U256::from(origin.number),
+        U256::from(origin.timestamp),
+        origin.base_fee,
+        origin.hash,
+        origin.state_root,
+    );
+    let input = SET_L1_ORACLE_VALUES_ABI
+        .encode_with_selector(*SET_L1_ORACLE_VALUES_SELECTOR, set_l1_oracle_values_input)
+        .expect("failed to encode setL1OracleValues input");
+    // Construct L1 oracle update transaction
+    let mut tx = TransactionRequest::new()
+        .to(config.l1_oracle)
+        .gas(150_000_000) // TODO[zhe]: consider to lower this number
+        .value(0)
+        .data(input)
+        .into();
+    // TODO[zhe]: here we let the provider to fill in the gas price
+    // TODO[zhe]: consider to make it constant?
+    client
+        .fill_transaction(&mut tx, Some((parent_l2_block.number + 1).into()))
+        .await?;
+    let signature = client.signer().sign_transaction(&tx).await?;
+    let raw_tx = tx.rlp_signed(&signature);
+    Ok(Some(vec![RawTransaction(raw_tx.0.into())]))
 }
 
 /// Returns the next l2 block randao, reusing that of the `next_origin`.
@@ -137,13 +195,14 @@ mod tests {
     use crate::{common::BlockInfo, driver::sequencing::SequencingPolicy};
 
     use super::{config, unix_now, AttributesBuilder};
-    use ethers::abi::Address;
+    use ethers::{abi::Address, providers::Provider};
     use eyre::Result;
+    use std::env;
 
     #[test]
     fn test_is_ready() -> Result<()> {
         // Setup.
-        let config = config::Config {
+        let config: config::Config = config::Config {
             blocktime: 2,
             max_seq_drift: 0, // anything
             max_safe_lag: 10,
@@ -151,8 +210,13 @@ mod tests {
                 batch_sender: Address::zero(),
                 gas_limit: 1,
             }, // anything
+            l1_oracle: Address::zero(),
+            // random publicly known private key
+            sequencer_private_key:
+                "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".to_string(),
         };
-        let attrs_builder = AttributesBuilder::new(config.clone());
+        let provider = Provider::try_from(env::var("L2_TEST_RPC_URL").unwrap()).unwrap();
+        let attrs_builder = AttributesBuilder::new(config.clone(), provider);
         // Run test cases.
         let cases = vec![(true, true), (true, false), (false, true), (false, false)];
         for case in cases.iter() {

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -129,8 +129,8 @@ impl SequencingPolicy for AttributesBuilder {
     }
 }
 
-// TODO: implement. requires l1 info tx. requires signer...
-// Creates the transaction(s) to include at the top of the next l2 block.
+// Creates the `L1Oracle::setL1OracleValues` transaction to include at the top of
+// the next l2 block, which marks the start of an epoch.
 async fn create_l1_oracle_update_transaction(
     config: &config::Config,
     client: &SignerMiddleware<Provider<Http>, LocalWallet>,
@@ -155,7 +155,7 @@ async fn create_l1_oracle_update_transaction(
         .expect("failed to encode setL1OracleValues input");
     // Construct L1 oracle update transaction
     let mut tx = TransactionRequest::new()
-        .to(config.l1_oracle)
+        .to(config.l1_oracle_address)
         .gas(150_000_000) // TODO[zhe]: consider to lower this number
         .value(0)
         .data(input)
@@ -209,7 +209,7 @@ mod tests {
                 batch_sender: Address::zero(),
                 gas_limit: 1,
             }, // anything
-            l1_oracle: Address::zero(),
+            l1_oracle_address: Address::zero(),
             // random publicly known private key
             sequencer_private_key:
                 "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".to_string(),

--- a/src/specular/stages/batcher_transactions.rs
+++ b/src/specular/stages/batcher_transactions.rs
@@ -1,31 +1,12 @@
 use std::sync::mpsc;
 
-use ethers::{
-    abi::parse_abi_str,
-    contract::Lazy,
-    prelude::BaseContract,
-    types::{Bytes, Selector},
-};
+use ethers::types::Bytes;
 use eyre::Result;
 use std::collections::VecDeque;
 
 use crate::derive::stages::batcher_transactions::BatcherTransactionMessage;
 use crate::derive::PurgeableIterator;
-
-type AppendTxBatchInput = Bytes;
-const APPEND_TX_BATCH_ABI_STR: &str = r#"[
-    function appendTxBatch(bytes calldata txBatchData) external
-]"#;
-static APPEND_TX_BATCH_ABI: Lazy<BaseContract> = Lazy::new(|| {
-    BaseContract::from(parse_abi_str(APPEND_TX_BATCH_ABI_STR).expect("abi must be valid"))
-});
-static APPEND_TX_BATCH_SELECTOR: Lazy<Selector> = Lazy::new(|| {
-    APPEND_TX_BATCH_ABI
-        .abi()
-        .function("appendTxBatch")
-        .expect("function must be present")
-        .short_signature()
-});
+use crate::specular::common::{AppendTxBatchInput, APPEND_TX_BATCH_ABI, APPEND_TX_BATCH_SELECTOR};
 
 /// The first stage in Specular's derivation pipeline.
 /// This stage consumes [BatcherTransactionMessage]s and produces [SpecularBatcherTransaction]s.

--- a/src/specular/stages/batcher_transactions.rs
+++ b/src/specular/stages/batcher_transactions.rs
@@ -12,9 +12,9 @@ use std::collections::VecDeque;
 use crate::derive::stages::batcher_transactions::BatcherTransactionMessage;
 use crate::derive::PurgeableIterator;
 
-type AppendTxBatchInput = (U256, Bytes);
+type AppendTxBatchInput = Bytes;
 const APPEND_TX_BATCH_ABI_STR: &str = r#"[
-    function appendTxBatch(uint256 txBatchVersion,bytes calldata txBatch) external
+    function appendTxBatch(bytes calldata txBatchData) external
 ]"#;
 static APPEND_TX_BATCH_ABI: Lazy<BaseContract> = Lazy::new(|| {
     BaseContract::from(parse_abi_str(APPEND_TX_BATCH_ABI_STR).expect("abi must be valid"))
@@ -80,7 +80,7 @@ impl SpecularBatcherTransactions {
 pub struct SpecularBatcherTransaction {
     /// The block number of the L1 block that included this transaction.
     pub l1_inclusion_block: u64,
-    pub version: u64,
+    pub version: u8,
     pub tx_batch: Bytes,
 }
 
@@ -88,19 +88,15 @@ impl SpecularBatcherTransaction {
     /// Create a new batcher transaction from raw transaction data.
     /// Only `appendTxBatch` calls are considered valid.
     pub fn new(l1_inclusion_block: u64, data: &[u8]) -> Result<Self> {
-        if data.len() < 4 {
-            eyre::bail!("invalid transaction data");
-        }
-        if data[..4] != *APPEND_TX_BATCH_SELECTOR {
-            eyre::bail!("not appendTxBatch call");
-        }
-
-        let (tx_batch_version, tx_batch): AppendTxBatchInput =
-            APPEND_TX_BATCH_ABI.decode("appendTxBatch", data)?;
+        let tx_batch: AppendTxBatchInput =
+            APPEND_TX_BATCH_ABI.decode_with_selector(*APPEND_TX_BATCH_SELECTOR, data)?;
+        
+        let version = tx_batch.0[0];
+        let tx_batch = tx_batch.0.slice(1..).into();
 
         Ok(Self {
             l1_inclusion_block,
-            version: tx_batch_version.as_u64(),
+            version,
             tx_batch,
         })
     }

--- a/src/specular/stages/batcher_transactions.rs
+++ b/src/specular/stages/batcher_transactions.rs
@@ -4,7 +4,7 @@ use ethers::{
     abi::parse_abi_str,
     contract::Lazy,
     prelude::BaseContract,
-    types::{Bytes, Selector, U256},
+    types::{Bytes, Selector},
 };
 use eyre::Result;
 use std::collections::VecDeque;
@@ -90,7 +90,7 @@ impl SpecularBatcherTransaction {
     pub fn new(l1_inclusion_block: u64, data: &[u8]) -> Result<Self> {
         let tx_batch: AppendTxBatchInput =
             APPEND_TX_BATCH_ABI.decode_with_selector(*APPEND_TX_BATCH_SELECTOR, data)?;
-        
+
         let version = tx_batch.0[0];
         let tx_batch = tx_batch.0.slice(1..).into();
 

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -108,10 +108,45 @@ where
             }
         };
 
-        // TODO[zhe]: handle empty epoch
-        let batch = derived_batch;
+        // TODO[zhe]: fix correct epoch fetching
+        let batch = if derived_batch.is_none() {
+            let state = self.state.read().unwrap();
 
-        Ok(batch.map(|batch| batch.into()))
+            let current_l1_block = state.current_epoch_num;
+            let safe_head = state.safe_head;
+            let epoch = state.safe_epoch;
+            let next_epoch = state.epoch_by_number(epoch.number + 1);
+            let seq_window_size = self.config.chain.seq_window_size;
+
+            if let Some(next_epoch) = next_epoch {
+                if current_l1_block > epoch.number + seq_window_size {
+                    let next_timestamp = safe_head.timestamp + self.config.chain.blocktime;
+                    let epoch = if next_timestamp < next_epoch.timestamp {
+                        epoch
+                    } else {
+                        next_epoch
+                    };
+
+                    Some(Batch {
+                        epoch_num: epoch.number,
+                        epoch_hash: epoch.hash,
+                        parent_hash: Default::default(),
+                        timestamp: next_timestamp,
+                        transactions: Vec::new(),
+                        l1_inclusion_block: current_l1_block,
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            derived_batch.map(|batch| batch.into())
+        };
+
+
+        Ok(batch)
     }
 
     /// Determine whether a batch is valid.
@@ -208,8 +243,9 @@ impl SpecularBatchV0 {
 
 impl From<SpecularBatchV0> for Batch {
     fn from(val: SpecularBatchV0) -> Self {
+        // TODO[zhe]: this is incorrect, use the correct epoch when derivation pipeline is fixed
         Batch {
-            epoch_num: val.l1_inclusion_block, // TODO[zhe]: we simply let the epoch number be the l1 inclusion block number
+            epoch_num: val.l1_inclusion_block,
             epoch_hash: val.l1_inclusion_hash,
             parent_hash: Default::default(), // we don't care about parent hash
             timestamp: val.timestamp,

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -12,9 +12,15 @@ use crate::config::Config;
 use crate::derive::stages::batches::Batch;
 use crate::derive::state::State;
 use crate::derive::PurgeableIterator;
-use ethers::utils::rlp::Rlp;
+use ethers::{
+    types::Transaction,
+    utils::rlp::{Decodable, Rlp},
+};
 
 use super::batcher_transactions::SpecularBatcherTransaction;
+use crate::specular::common::{
+    SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR,
+};
 
 /// The second stage of Specular's derive pipeline.
 /// This stage consumes [SpecularBatcherTransaction]s and produces [SpecularBatchV0]s.
@@ -76,11 +82,7 @@ where
     fn try_next(&mut self) -> Result<Option<Batch>> {
         let batcher_transaction = self.batcher_transaction_iter.next();
         if let Some(batcher_transaction) = batcher_transaction {
-            let batches = decode_batches(
-                &batcher_transaction,
-                &self.state,
-                self.config.chain.blocktime,
-            )?;
+            let batches = decode_batches(&batcher_transaction, &self.state, &self.config)?;
             batches.into_iter().for_each(|batch| {
                 tracing::debug!(
                     "saw batch: t={}, bn={:?}, e={}",
@@ -190,54 +192,62 @@ where
 fn decode_batches(
     batcher_tx: &SpecularBatcherTransaction,
     state: &RwLock<State>,
-    blocktime: u64,
+    config: &Config,
 ) -> Result<Vec<SpecularBatchV0>> {
     if batcher_tx.version != 0 {
         eyre::bail!("unsupported batcher transaction version");
     }
-    decode_batches_v0(batcher_tx, state, blocktime)
+    decode_batches_v0(batcher_tx, state, config)
 }
 
 /// Decodes [SpecularBatchV0]s from a [SpecularBatcherTransaction].
 /// [SpecularBatcherTransaction] contains multiple lists of [SpecularBatchV0]s.
-/// For each batch list in [SpecularBatcherTransaction], if the first byte of the list is 0,
-/// the first [SpecularBatchV0] in the list is an epoch update; otherwise, it extends the current epoch.
+/// For each batch list in [SpecularBatcherTransaction], the first [SpecualrBatchV0] is an epoch update
+/// if the first transaction in the batch is a `setL1OracleValues` call.
 fn decode_batches_v0(
     batcher_tx: &SpecularBatcherTransaction,
     state: &RwLock<State>,
-    blocktime: u64,
+    config: &Config,
 ) -> Result<Vec<SpecularBatchV0>> {
     let mut batches = Vec::new();
     let batch_lists = Rlp::new(&batcher_tx.tx_batch);
+    // Get l2 safe head info.
+    let state = state.read().unwrap();
+    let safe_l2_num = state.safe_head.number;
+    let safe_l2_ts = state.safe_head.timestamp;
+    // Get l2 safe epoch info.
+    let mut epoch_num = state.safe_epoch.number;
+    let mut epoch_hash = state.safe_epoch.hash;
+    // Decode each batch list in the batcher transaction.
     for batch_list in batch_lists.iter() {
-        // Decode the epoch-update indicator.
-        let is_epoch_update = batch_list.val_at::<u8>(0)? == 0;
-        // Get l2 safe head info.
-        let state = state.read().unwrap();
-        let safe_l2_num = state.safe_head.number;
-        let safe_l2_ts = state.safe_head.timestamp;
-        // Decode the first l2 block number.
-        let first_l2_block_num: u64 = batch_list.val_at(1)?;
-        let first_l2_block_timestamp = (first_l2_block_num - safe_l2_num) * blocktime + safe_l2_ts;
-        // Decode the epoch number and hash (or extend the current epoch).
-        let (epoch_num, epoch_hash) = if is_epoch_update {
-            let epoch_num: u64 = batch_list.val_at(2)?;
-            let epoch_hash: H256 = batch_list.val_at(3)?;
-            (epoch_num, epoch_hash)
-        } else {
-            (state.safe_epoch.number, state.safe_epoch.hash)
-        };
-        // Decode the transaction batches.
-        let batches_offset = if is_epoch_update { 4 } else { 2 };
-        for (batch, idx) in batch_list.at(batches_offset)?.iter().zip(0u64..) {
+        // Decode the first l2 block number at offset 0.
+        let first_l2_block_num: u64 = batch_list.val_at(0)?;
+        let first_l2_block_timestamp =
+            (first_l2_block_num - safe_l2_num) * config.chain.blocktime + safe_l2_ts;
+        // Decode the transaction batches at offset 1.
+        for (batch, idx) in batch_list.at(1)?.iter().zip(0u64..) {
+            let transactions: Vec<RawTransaction> = batch.as_list()?;
+            // Try decode the `setL1OacleValues` call if it is the first batch in the list.
+            let l1_oracle_values = if idx == 0 {
+                transactions
+                    .first()
+                    .and_then(|tx| try_decode_l1_oracle_values(tx, config))
+            } else {
+                None
+            };
+            // Update the local epoch info if there's a new epoch.
+            if let Some((new_epoch_num, _, _, new_epoch_hash, _)) = l1_oracle_values {
+                epoch_num = new_epoch_num.as_u64();
+                epoch_hash = new_epoch_hash;
+            }
             let batch = SpecularBatchV0 {
                 epoch_num,
                 epoch_hash,
-                timestamp: first_l2_block_timestamp + idx * blocktime,
-                transactions: batch.as_list()?,
+                timestamp: first_l2_block_timestamp + idx * config.chain.blocktime,
+                transactions,
                 l2_block_number: first_l2_block_num + idx,
                 l1_inclusion_block: batcher_tx.l1_inclusion_block,
-                is_epoch_update: idx == 0 && is_epoch_update, // true only if first batch
+                l1_oracle_values,
             };
             batches.push(batch);
         }
@@ -261,7 +271,7 @@ pub struct SpecularBatchV0 {
     pub l2_block_number: u64,
     pub transactions: Vec<RawTransaction>,
     pub l1_inclusion_block: u64,
-    pub is_epoch_update: bool,
+    pub l1_oracle_values: Option<SetL1OracleValuesInput>,
 }
 
 impl SpecularBatchV0 {
@@ -281,4 +291,20 @@ impl From<SpecularBatchV0> for Batch {
             l1_inclusion_block: val.l1_inclusion_block,
         }
     }
+}
+
+fn try_decode_l1_oracle_values(
+    tx: &RawTransaction,
+    config: &Config,
+) -> Option<SetL1OracleValuesInput> {
+    let tx = Transaction::decode(&Rlp::new(&tx.0)).ok()?;
+    if tx.to? != config.chain.meta.l1_oracle {
+        return None;
+    }
+
+    let input = SET_L1_ORACLE_VALUES_ABI
+        .decode_with_selector(*SET_L1_ORACLE_VALUES_SELECTOR, &tx.input.0)
+        .ok()?;
+
+    Some(input)
 }

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -107,7 +107,6 @@ where
             }
         };
 
-        // TODO[zhe]: fix correct epoch fetching
         let batch = if derived_batch.is_none() {
             let state = self.state.read().unwrap();
 
@@ -130,7 +129,7 @@ where
                     Some(Batch {
                         epoch_num: epoch.number,
                         epoch_hash: epoch.hash,
-                        parent_hash: Default::default(),
+                        parent_hash: Default::default(), // We don't care about parent_hash
                         timestamp: next_timestamp,
                         transactions: Vec::new(),
                         l1_inclusion_block: current_l1_block,

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -122,7 +122,6 @@ where
                     let epoch = if next_timestamp < next_epoch.timestamp {
                         epoch
                     } else {
-                        // TODO[zhe]: we might have to be stuck in the same epoch forever, so this is incorrect
                         next_epoch
                     };
 
@@ -272,7 +271,6 @@ impl SpecularBatchV0 {
 
 impl From<SpecularBatchV0> for Batch {
     fn from(val: SpecularBatchV0) -> Self {
-        // TODO[zhe]: this is incorrect, use the correct epoch when derivation pipeline is fixed
         Batch {
             epoch_num: val.epoch_num,
             epoch_hash: val.epoch_hash,

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -145,7 +145,6 @@ where
             derived_batch.map(|batch| batch.into())
         };
 
-
         Ok(batch)
     }
 


### PR DESCRIPTION
# Core changes:
- Implement the new batcher transaction format, where `epoch_num` and `epoch_hash` are added when a new epoch starts
  - Improvement of #15. The new batcher transaction can contain multiple batch lists now.
- Implement the L1 oracle update transaction submission in sequencer
  - Add `--sequencer-pk-file` cli flag for passing in the sequencer private key (plain text)
- Fix the derivation pipeline with correct epoch semantics when creating empty batches

# Notes:
- Depends on #9 
- The sequencer drift/L1 oracle transaction update validation inside the derivation pipeline will come in #16 