### PR TITLE
Several bug fixes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -167,8 +167,6 @@ pub struct ProtocolMetaConfig {
     pub enable_config_updates: bool,
     pub enable_deposited_txs: bool,
     pub enable_full_derivation: bool,
-    /// Specular: The L2-predeploy L1 oracle contract address
-    pub l1_oracle: Address,
 }
 
 impl ProtocolMetaConfig {
@@ -177,7 +175,6 @@ impl ProtocolMetaConfig {
             enable_config_updates: true,
             enable_deposited_txs: true,
             enable_full_derivation: true,
-            l1_oracle: Address::zero(),
         }
     }
 }

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -46,19 +46,7 @@ impl<E: Engine> EngineDriver<E> {
 
         if let Some(block) = block {
             if should_skip(&block, &attributes)? {
-                if update_safe {
-                    self.skip_attributes(attributes, block).await
-                } else {
-                    // TODO: check this
-                    self.unsafe_head = BlockInfo::try_from(block)?;
-                    self.unsafe_epoch = *attributes.epoch.as_ref().unwrap();
-                    tracing::warn!(
-                        "skipping attributes built by the sequencer | block#: {}, epoch#: {}",
-                        self.unsafe_head.number,
-                        self.unsafe_epoch.number
-                    );
-                    Ok(())
-                }
+                self.skip_attributes(attributes, block).await
             } else {
                 self.unsafe_head = self.safe_head;
                 self.process_attributes(attributes, update_safe).await

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -9,7 +9,6 @@ use ethers::{
 use eyre::Result;
 use tokio::time::{sleep, Duration};
 
-use crate::common::RawTransaction;
 use crate::{
     common::{BlockInfo, Epoch},
     config::Config,
@@ -236,13 +235,10 @@ fn should_skip(block: &Block<Transaction>, attributes: &PayloadAttributes) -> Re
     tracing::debug!("block: {:?}", block);
     tracing::debug!("attributes: {:?}", attributes);
 
-    // TODO: temp fixes
-    let empty_txs: Vec<RawTransaction> = Vec::new();
-
     let attributes_hashes = attributes
         .transactions
         .as_ref()
-        .unwrap_or(&empty_txs)
+        .unwrap()
         .iter()
         .map(|tx| H256(keccak256(&tx.0)))
         .collect::<Vec<_>>();

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -49,12 +49,14 @@ impl<E: Engine> EngineDriver<E> {
                 if update_safe {
                     self.skip_attributes(attributes, block).await
                 } else {
-                    // TODO: temp fix
-                    let new_epoch = *attributes.epoch.as_ref().unwrap();
-                    let new_head = BlockInfo::try_from(block)?;
-                    self.unsafe_head = new_head;
-                    self.unsafe_epoch = new_epoch;
-                    tracing::warn!("skipping attributes");
+                    // TODO: check this
+                    self.unsafe_head = BlockInfo::try_from(block)?;
+                    self.unsafe_epoch = *attributes.epoch.as_ref().unwrap();
+                    tracing::warn!(
+                        "skipping attributes built by the sequencer | block#: {}, epoch#: {}",
+                        self.unsafe_head.number,
+                        self.unsafe_epoch.number
+                    );
                     Ok(())
                 }
             } else {

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -256,13 +256,15 @@ impl InnerWatcher {
         if self.current_block > self.finalized_block {
             let finalized_block = self.get_finalized().await?;
 
-            self.finalized_block = finalized_block;
-            self.block_update_sender
-                .send(BlockUpdate::FinalityUpdate(finalized_block))
-                .await?;
-
-            self.unfinalized_blocks
-                .retain(|b| b.number > self.finalized_block)
+            // Only update finalized block if it has changed to avoid spamming the channel.
+            if self.finalized_block < finalized_block {
+                self.finalized_block = finalized_block;
+                self.block_update_sender
+                    .send(BlockUpdate::FinalityUpdate(finalized_block))
+                    .await?;
+                self.unfinalized_blocks
+                    .retain(|b| b.number > self.finalized_block)
+            }
         }
 
         if self.current_block > self.head_block {

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -258,6 +258,7 @@ impl InnerWatcher {
 
             // Only update finalized block if it has changed to avoid spamming the channel.
             if self.finalized_block < finalized_block {
+                tracing::debug!("[l1] finalized block updated to {}", finalized_block);
                 self.finalized_block = finalized_block;
                 self.block_update_sender
                     .send(BlockUpdate::FinalityUpdate(finalized_block))

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -71,9 +71,9 @@ impl From<ExternalChainConfig> for ChainConfig {
             system_config: SystemConfig {
                 batch_sender: external.genesis.system_config.batcher_addr,
                 gas_limit: U256::from(external.genesis.system_config.gas_limit),
-                l1_fee_overhead: U256::from(0), // not used
-                l1_fee_scalar: U256::from(0),   // not used
-                unsafe_block_signer: external.genesis.system_config.batcher_addr, // not used?
+                l1_fee_overhead: U256::from(0),       // not used
+                l1_fee_scalar: U256::from(0),         // not used
+                unsafe_block_signer: Address::zero(), // not used?
             },
             batch_inbox: external.batch_inbox_address,
             deposit_contract: Address::zero(),         // not used

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -96,7 +96,6 @@ impl ProtocolMetaConfig {
             enable_config_updates: false,
             enable_deposited_txs: false,
             enable_full_derivation: false,
-            l1_oracle: SystemAccounts::default().l1_oracle,
         }
     }
 }

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -73,7 +73,7 @@ impl From<ExternalChainConfig> for ChainConfig {
                 gas_limit: U256::from(external.genesis.system_config.gas_limit),
                 l1_fee_overhead: U256::from(0),       // not used
                 l1_fee_scalar: U256::from(0),         // not used
-                unsafe_block_signer: Address::zero(), // not used?
+                unsafe_block_signer: external.genesis.system_config.batcher_addr, // not used?
             },
             batch_inbox: external.batch_inbox_address,
             deposit_contract: Address::zero(),         // not used
@@ -85,18 +85,18 @@ impl From<ExternalChainConfig> for ChainConfig {
             regolith_time: 0, // not used
             blocktime: external.block_time,
             l2_to_l1_message_passer: Address::zero(), // not used?
-            meta: ProtocolMetaConfig::specular(SystemAccounts::default().l1_oracle),
+            meta: ProtocolMetaConfig::specular(),
         }
     }
 }
 
 impl ProtocolMetaConfig {
-    pub fn specular(l1_oracle: Address) -> Self {
+    pub fn specular() -> Self {
         Self {
             enable_config_updates: false,
             enable_deposited_txs: false,
             enable_full_derivation: false,
-            l1_oracle,
+            l1_oracle: SystemAccounts::default().l1_oracle,
         }
     }
 }

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -71,8 +71,8 @@ impl From<ExternalChainConfig> for ChainConfig {
             system_config: SystemConfig {
                 batch_sender: external.genesis.system_config.batcher_addr,
                 gas_limit: U256::from(external.genesis.system_config.gas_limit),
-                l1_fee_overhead: U256::from(0),       // not used
-                l1_fee_scalar: U256::from(0),         // not used
+                l1_fee_overhead: U256::from(0), // not used
+                l1_fee_scalar: U256::from(0),   // not used
                 unsafe_block_signer: external.genesis.system_config.batcher_addr, // not used?
             },
             batch_inbox: external.batch_inbox_address,

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -5,6 +5,7 @@ use crate::config::{Config as MagiConfig, SystemConfig as MagiSystemConfig};
 /// Sequencing policy configuration.
 #[derive(Clone, Debug)]
 pub struct Config {
+    pub l2_chain_id: u64,
     pub max_safe_lag: u64,
     pub max_seq_drift: u64,
     pub blocktime: u64,
@@ -24,6 +25,7 @@ pub struct SystemConfig {
 impl Config {
     pub fn new(config: &MagiConfig) -> Self {
         Self {
+            l2_chain_id: config.chain.l2_chain_id,
             max_safe_lag: config.local_sequencer.max_safe_lag,
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -10,7 +10,6 @@ pub struct Config {
     pub max_seq_drift: u64,
     pub blocktime: u64,
     pub system_config: SystemConfig,
-    pub l1_oracle_address: H160,
     pub sequencer_private_key: String,
 }
 
@@ -30,7 +29,6 @@ impl Config {
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
             system_config: SystemConfig::new(&config.chain.system_config),
-            l1_oracle_address: config.chain.meta.l1_oracle,
             sequencer_private_key: config
                 .local_sequencer
                 .private_key

--- a/src/specular/sequencing/mod.rs
+++ b/src/specular/sequencing/mod.rs
@@ -16,8 +16,9 @@ use crate::{
     l1::L1BlockInfo,
 };
 
-use crate::specular::common::{
-    SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR,
+use crate::specular::{
+    common::{SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR},
+    config::SystemAccounts,
 };
 
 pub mod config;
@@ -106,7 +107,7 @@ impl<M: Middleware + 'static> AttributesBuilder<M> {
             .expect("failed to encode setL1OracleValues input");
         // Construct L1 oracle update transaction
         let mut tx = TransactionRequest::new()
-            .to(self.config.l1_oracle_address)
+            .to(SystemAccounts::default().l1_oracle)
             .gas(15_000_000) // TODO[zhe]: consider to lower this number; temporarily lowering it
             .value(0)
             .data(input)
@@ -214,7 +215,6 @@ mod tests {
                 batch_sender: Address::zero(),
                 gas_limit: 1,
             }, // anything
-            l1_oracle_address: Address::zero(),
             // random publicly known private key
             sequencer_private_key:
                 "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".to_string(),

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -18,8 +18,9 @@ use ethers::{
 };
 
 use super::batcher_transactions::SpecularBatcherTransaction;
-use crate::specular::common::{
-    SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR,
+use crate::specular::{
+    common::{SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR},
+    config::SystemAccounts,
 };
 
 /// The second stage of Specular's derive pipeline.
@@ -218,20 +219,46 @@ fn decode_batches_v0(
     // Get l2 safe epoch info.
     let mut epoch_num = state.safe_epoch.number;
     let mut epoch_hash = state.safe_epoch.hash;
+    // Record the local l2 block number to check for duplicates and missing blocks.
+    let mut local_l2_num = safe_l2_num;
     // Decode each batch list in the batcher transaction.
     for batch_list in batch_lists.iter() {
         // Decode the first l2 block number at offset 0.
-        let first_l2_block_num: u64 = batch_list.val_at(0)?;
-        let first_l2_block_timestamp =
-            (first_l2_block_num - safe_l2_num) * config.chain.blocktime + safe_l2_ts;
+        let batch_first_l2_num: u64 = batch_list.val_at(0)?;
+        // Check for duplicates.
+        if batch_first_l2_num < local_l2_num {
+            tracing::warn!("invalid batcher transaction: contains already accepted batches | safe_head={} first_l2_block_num={}", local_l2_num, batch_first_l2_num);
+            eyre::bail!("invalid batcher transaction: contains already accepted batches");
+        }
+        // Insert empty batches for missing blocks.
+        for i in local_l2_num + 1..batch_first_l2_num {
+            let batch = SpecularBatchV0 {
+                epoch_num,
+                epoch_hash,
+                timestamp: (i - safe_l2_num) * config.chain.blocktime + safe_l2_ts,
+                transactions: Vec::new(),
+                l2_block_number: i,
+                l1_inclusion_block: state.current_epoch_num,
+                l1_oracle_values: None,
+            };
+            tracing::info!(
+                "inserting empty batch | num={} ts={}",
+                batch.l2_block_number,
+                batch.timestamp,
+            );
+            batches.push(batch);
+        }
+        // Update the local l2 block number.
+        // We're supposed to have inserted empty batches until right before the first batch in the list.
+        local_l2_num = batch_first_l2_num - 1;
+        let batch_first_l2_ts =
+            (batch_first_l2_num - safe_l2_num) * config.chain.blocktime + safe_l2_ts;
         // Decode the transaction batches at offset 1.
         for (batch, idx) in batch_list.at(1)?.iter().zip(0u64..) {
             let transactions: Vec<RawTransaction> = batch.as_list()?;
             // Try decode the `setL1OacleValues` call if it is the first batch in the list.
             let l1_oracle_values = if idx == 0 {
-                transactions
-                    .first()
-                    .and_then(|tx| try_decode_l1_oracle_values(tx, config))
+                transactions.first().and_then(try_decode_l1_oracle_values)
             } else {
                 None
             };
@@ -240,16 +267,19 @@ fn decode_batches_v0(
                 epoch_num = new_epoch_num.as_u64();
                 epoch_hash = new_epoch_hash;
             }
+            // Create the batch.
             let batch = SpecularBatchV0 {
                 epoch_num,
                 epoch_hash,
-                timestamp: first_l2_block_timestamp + idx * config.chain.blocktime,
+                timestamp: batch_first_l2_ts + idx * config.chain.blocktime,
                 transactions,
-                l2_block_number: first_l2_block_num + idx,
+                l2_block_number: batch_first_l2_num + idx,
                 l1_inclusion_block: batcher_tx.l1_inclusion_block,
                 l1_oracle_values,
             };
             batches.push(batch);
+            // Update the local l2 block number.
+            local_l2_num += 1;
         }
     }
 
@@ -293,12 +323,9 @@ impl From<SpecularBatchV0> for Batch {
     }
 }
 
-fn try_decode_l1_oracle_values(
-    tx: &RawTransaction,
-    config: &Config,
-) -> Option<SetL1OracleValuesInput> {
+fn try_decode_l1_oracle_values(tx: &RawTransaction) -> Option<SetL1OracleValuesInput> {
     let tx = Transaction::decode(&Rlp::new(&tx.0)).ok()?;
-    if tx.to? != config.chain.meta.l1_oracle {
+    if tx.to? != SystemAccounts::default().l1_oracle {
         return None;
     }
 

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -241,7 +241,7 @@ fn decode_batches_v0(
                 l1_inclusion_block: state.current_epoch_num,
                 l1_oracle_values: None,
             };
-            tracing::info!(
+            tracing::trace!(
                 "inserting empty batch | num={} ts={}",
                 batch.l2_block_number,
                 batch.timestamp,


### PR DESCRIPTION
# Core changes

- Remove configurations of `l1_oracle` address, instead use `SystemAccounts::default().l1_oracle`
- Optimization on `ChainWatcher` to avoid duplicate finality updates spamming the channel
- Fix batch decoding. Now empty batches are inserted to meet the specification.
- Fix `AttributesBuilder`. 
  - Now the `Signer` is with the correct chain ID.
  - Now the built attribute uses empty vec instead of `None` for empty transaction list to be compatible with engine api.
  - Now the `SetL1OracleValues` is filled with the latest block if the `target_l2_block_number` does not exist on-chain.