### PR TITLE
Move sequencing to concurrent coroutine to unblock driver control loop

### DIFF
--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{PathBuf};
 use std::{env::current_dir, process};
 
 use clap::Parser;
@@ -91,7 +91,7 @@ impl Cli {
             "optimism-sepolia" => ChainConfig::optimism_sepolia(),
             "base" => ChainConfig::base(),
             "base-goerli" => ChainConfig::base_goerli(),
-            file if file.starts_with("sp_") => ChainConfig::from_specular_json(file),
+            path if ChainConfig::is_specular_config(path) => ChainConfig::from_specular_json(path),
             file if file.ends_with(".json") => ChainConfig::from_json(file),
             _ => panic!(
                 "Invalid network name. \\

--- a/bin/magi.rs
+++ b/bin/magi.rs
@@ -1,4 +1,4 @@
-use std::path::{PathBuf};
+use std::path::PathBuf;
 use std::{env::current_dir, process};
 
 use clap::Parser;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -11,7 +11,10 @@ use ethers::{
 use eyre::Result;
 use reqwest::Url;
 use tokio::{
-    sync::watch::{self, Sender},
+    sync::{
+        watch::{self, Sender},
+        RwLock as TokioRwLock,
+    },
     time::sleep,
 };
 
@@ -26,9 +29,9 @@ use crate::{
     telemetry::metrics,
 };
 
-use self::engine_driver::EngineDriver;
+use self::engine_driver::{handle_attributes, ChainHead, EngineDriver};
 
-mod engine_driver;
+pub mod engine_driver;
 mod info;
 pub mod sequencing;
 mod types;
@@ -36,11 +39,11 @@ pub use types::*;
 
 /// Driver is responsible for advancing the execution node by feeding
 /// the derived chain into the engine API
-pub struct Driver<E: Engine, S: sequencing::SequencingSource<E>> {
+pub struct Driver<E: Engine> {
     /// The derivation pipeline
     pipeline: Pipeline,
     /// The engine driver
-    engine_driver: EngineDriver<E>,
+    pub engine_driver: Arc<TokioRwLock<EngineDriver<E>>>,
     /// List of unfinalized L2 blocks with their epochs, L1 inclusions, and sequence numbers
     unfinalized_blocks: Vec<(BlockInfo, Epoch, u64, u64)>,
     /// Current finalized L1 block number
@@ -48,7 +51,7 @@ pub struct Driver<E: Engine, S: sequencing::SequencingSource<E>> {
     /// List of unsafe blocks that have not been applied yet
     future_unsafe_blocks: Vec<ExecutionPayload>,
     /// State struct to keep track of global state
-    state: Arc<RwLock<State>>,
+    pub state: Arc<RwLock<State>>,
     /// L1 chain watcher
     chain_watcher: ChainWatcher,
     /// Channel to receive the shutdown signal from
@@ -61,16 +64,10 @@ pub struct Driver<E: Engine, S: sequencing::SequencingSource<E>> {
     network_service: Option<Service>,
     /// Channel timeout length
     channel_timeout: u64,
-    /// Local sequencing source
-    sequencing_src: Option<S>,
 }
 
-impl<S: sequencing::SequencingSource<EngineApi>> Driver<EngineApi, S> {
-    pub async fn from_config(
-        config: Config,
-        shutdown_recv: watch::Receiver<bool>,
-        sequencing_src: Option<S>,
-    ) -> Result<Self> {
+impl Driver<EngineApi> {
+    pub async fn from_config(config: Config, shutdown_recv: watch::Receiver<bool>) -> Result<Self> {
         let client = reqwest::ClientBuilder::new()
             .timeout(Duration::from_secs(5))
             .build()?;
@@ -116,7 +113,7 @@ impl<S: sequencing::SequencingSource<EngineApi>> Driver<EngineApi, S> {
             .add_handler(Box::new(block_handler));
 
         Ok(Self {
-            engine_driver,
+            engine_driver: Arc::new(TokioRwLock::new(engine_driver)),
             pipeline,
             unfinalized_blocks: Vec::new(),
             finalized_l1_block_number: 0,
@@ -128,20 +125,18 @@ impl<S: sequencing::SequencingSource<EngineApi>> Driver<EngineApi, S> {
             unsafe_block_signer_sender,
             network_service: Some(service),
             channel_timeout: config.chain.channel_timeout,
-            sequencing_src,
         })
     }
 }
 
-impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
+impl<E: Engine> Driver<E> {
     /// Runs the Driver
     pub async fn start(&mut self) -> Result<()> {
         tracing::trace!("starting driver, waiting for engine...");
         self.await_engine_ready().await;
         tracing::trace!("engine ready; starting chain watcher...");
         self.chain_watcher.start()?;
-        tracing::trace!("chain watcher started");
-
+        tracing::info!("chain watcher started; advancing driver...");
         loop {
             self.check_shutdown().await;
 
@@ -165,8 +160,8 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
     }
 
     async fn await_engine_ready(&self) {
-        while !self.engine_driver.engine_ready().await {
-            tracing::trace!("waiting for engine ready...");
+        while !self.engine_driver.read().await.engine_ready().await {
+            tracing::info!("waiting for engine ready...");
             self.check_shutdown().await;
             sleep(Duration::from_secs(1)).await;
         }
@@ -177,10 +172,8 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
     async fn advance(&mut self) -> Result<()> {
         self.advance_safe_head().await?;
         self.advance_unsafe_head().await?;
-        self.advance_unsafe_head_by_attributes().await?;
-
-        self.update_finalized();
-        self.update_metrics();
+        self.update_finalized().await;
+        self.update_metrics().await;
         self.try_start_networking()?;
 
         Ok(())
@@ -191,7 +184,7 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
     /// does not successfully advance the node
     async fn advance_safe_head(&mut self) -> Result<()> {
         self.handle_next_block_update().await?;
-        self.update_state_head()?;
+        self.update_state_head().await?;
 
         for next_attributes in self.pipeline.by_ref() {
             let l1_inclusion_block = next_attributes
@@ -202,24 +195,27 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
                 .seq_number
                 .ok_or(eyre::eyre!("attributes without seq number"))?;
 
-            self.engine_driver
-                .handle_attributes(next_attributes, true)
-                .await?;
+            handle_attributes(
+                &next_attributes,
+                ChainHead::Safe,
+                self.engine_driver.clone(),
+            )
+            .await?;
 
+            let engine_driver = self.engine_driver.read().await;
             tracing::info!(
                 "safe head updated: {} {:?}",
-                self.engine_driver.safe_head.number,
-                self.engine_driver.safe_head.hash,
+                engine_driver.safe_head.number,
+                engine_driver.safe_head.hash,
             );
 
-            let new_safe_head = self.engine_driver.safe_head;
-            let new_safe_epoch = self.engine_driver.safe_epoch;
+            let new_safe_head = engine_driver.safe_head;
+            let new_safe_epoch = engine_driver.safe_epoch;
 
             self.state
                 .write()
                 .map_err(|_| eyre::eyre!("lock poisoned"))?
                 .update_safe_head(new_safe_head, new_safe_epoch);
-
             let unfinalized_entry = (
                 new_safe_head,
                 new_safe_epoch,
@@ -238,9 +234,10 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
             self.future_unsafe_blocks.push(payload);
         }
 
+        let mut engine_driver = self.engine_driver.write().await;
         self.future_unsafe_blocks.retain(|payload| {
             let unsafe_block_num = payload.block_number.as_u64();
-            let synced_block_num = self.engine_driver.unsafe_head.number;
+            let synced_block_num = engine_driver.unsafe_head.number;
 
             unsafe_block_num > synced_block_num && unsafe_block_num - synced_block_num < 1024
         });
@@ -248,37 +245,22 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
         let next_unsafe_payload = self
             .future_unsafe_blocks
             .iter()
-            .find(|p| p.parent_hash == self.engine_driver.unsafe_head.hash);
+            .find(|p| p.parent_hash == engine_driver.unsafe_head.hash);
 
         if let Some(payload) = next_unsafe_payload {
-            _ = self.engine_driver.handle_unsafe_payload(payload).await;
+            _ = engine_driver.handle_unsafe_payload(payload).await;
         }
 
         Ok(())
     }
 
-    /// Tries to process the next unbuilt payload attributes, building on the current forkchoice.
-    async fn advance_unsafe_head_by_attributes(&mut self) -> Result<()> {
-        let Some(sequencing_src) = &self.sequencing_src else {
-            return Ok(());
-        };
-        let Some(attrs) = sequencing_src
-            .get_next_attributes(&self.state, &self.engine_driver)
-            .await?
-        else {
-            return Ok(());
-        };
-        self.engine_driver.handle_attributes(attrs, false).await?;
-        Ok(())
-    }
-
-    fn update_state_head(&self) -> Result<()> {
+    async fn update_state_head(&self) -> Result<()> {
+        let engine_driver = self.engine_driver.read().await;
         let mut state = self
             .state
             .write()
             .map_err(|_| eyre::eyre!("lock poisoned"))?;
-
-        state.update_safe_head(self.engine_driver.safe_head, self.engine_driver.safe_epoch);
+        state.update_safe_head(engine_driver.safe_head, engine_driver.safe_epoch);
 
         Ok(())
     }
@@ -295,6 +277,11 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
                     self.unsafe_block_signer_sender
                         .send(l1_info.system_config.unsafe_block_signer)?;
 
+                    tracing::info!(
+                        "pushing into pipeline: l1_block#={} #batcher_txs={}",
+                        num,
+                        l1_info.batcher_transactions.len()
+                    );
                     self.pipeline
                         .push_batcher_transactions(l1_info.batcher_transactions.clone(), num)?;
 
@@ -308,24 +295,22 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
 
                     self.unfinalized_blocks.clear();
 
+                    let mut engine_driver = self.engine_driver.write().await;
                     let l1_start_block = get_l1_start_block(
-                        self.engine_driver.finalized_epoch.number,
+                        engine_driver.finalized_epoch.number,
                         self.channel_timeout,
                     );
 
                     self.chain_watcher
-                        .restart(l1_start_block, self.engine_driver.finalized_head.number)?;
+                        .restart(l1_start_block, engine_driver.finalized_head.number)?;
 
                     self.state
                         .write()
                         .map_err(|_| eyre::eyre!("lock poisoned"))?
-                        .purge(
-                            self.engine_driver.finalized_head,
-                            self.engine_driver.finalized_epoch,
-                        );
+                        .purge(engine_driver.finalized_head, engine_driver.finalized_epoch);
 
                     self.pipeline.purge()?;
-                    self.engine_driver.reorg();
+                    engine_driver.reorg();
                 }
                 BlockUpdate::FinalityUpdate(num) => {
                     self.finalized_l1_block_number = num;
@@ -336,7 +321,7 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
         Ok(())
     }
 
-    fn update_finalized(&mut self) {
+    async fn update_finalized(&mut self) {
         let new_finalized = self
             .unfinalized_blocks
             .iter()
@@ -346,7 +331,10 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
             .last();
 
         if let Some((head, epoch, _, _)) = new_finalized {
-            self.engine_driver.update_finalized(*head, *epoch);
+            self.engine_driver
+                .write()
+                .await
+                .update_finalized(*head, *epoch);
         }
 
         self.unfinalized_blocks
@@ -363,9 +351,10 @@ impl<E: Engine, S: sequencing::SequencingSource<E>> Driver<E, S> {
         Ok(())
     }
 
-    fn update_metrics(&self) {
-        metrics::FINALIZED_HEAD.set(self.engine_driver.finalized_head.number as i64);
-        metrics::SAFE_HEAD.set(self.engine_driver.safe_head.number as i64);
+    async fn update_metrics(&self) {
+        let engine_driver = self.engine_driver.read().await;
+        metrics::FINALIZED_HEAD.set(engine_driver.finalized_head.number as i64);
+        metrics::SAFE_HEAD.set(engine_driver.safe_head.number as i64);
         metrics::SYNCED.set(self.synced() as i64);
     }
 
@@ -420,11 +409,10 @@ mod tests {
             let provider = Provider::<Http>::try_from(config.l2_rpc_url.clone())?;
             let finalized_block = provider.get_block(block_id).await?.unwrap();
 
-            let seq_src = sequencing::none();
-            let driver = Driver::from_config(config, shutdown_recv, seq_src).await?;
+            let driver = Driver::from_config(config, shutdown_recv).await?;
 
             assert_eq!(
-                driver.engine_driver.finalized_head.number,
+                driver.engine_driver.read().await.finalized_head.number,
                 finalized_block.number.unwrap().as_u64()
             );
         }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     telemetry::metrics,
 };
 
-use self::engine_driver::{handle_attributes, ChainHead, EngineDriver};
+use self::engine_driver::{handle_attributes, ChainHeadType, EngineDriver};
 
 pub mod engine_driver;
 mod info;
@@ -132,9 +132,9 @@ impl Driver<EngineApi> {
 impl<E: Engine> Driver<E> {
     /// Runs the Driver
     pub async fn start(&mut self) -> Result<()> {
-        tracing::info!("starting chain watcher...");
+        tracing::trace!("starting chain watcher...");
         self.chain_watcher.start()?;
-        tracing::info!("chain watcher started; advancing driver...");
+        tracing::trace!("chain watcher started; advancing driver...");
         loop {
             self.check_shutdown().await;
 
@@ -197,7 +197,7 @@ impl<E: Engine> Driver<E> {
 
             handle_attributes(
                 &next_attributes,
-                ChainHead::Safe,
+                ChainHeadType::Safe,
                 self.engine_driver.clone(),
             )
             .await?;
@@ -335,6 +335,7 @@ impl<E: Engine> Driver<E> {
             .last();
 
         if let Some((head, epoch, _, _)) = new_finalized {
+            tracing::info!("updating finalized head: {:?}", head.number);
             self.engine_driver
                 .write()
                 .await

--- a/src/driver/sequencing/driver.rs
+++ b/src/driver/sequencing/driver.rs
@@ -1,0 +1,116 @@
+use std::{
+    process,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use eyre::Result;
+use tokio::{
+    sync::{watch, RwLock as TokioRwLock},
+    time::sleep,
+};
+
+use crate::{
+    derive::state::State,
+    driver::engine_driver::{execute_action, ChainHead, EngineDriver},
+    engine::{Engine, EngineApi},
+};
+
+use super::SequencingSource;
+
+pub struct SequencingDriver<E: Engine, S: SequencingSource> {
+    /// The engine driver
+    engine_driver: Arc<TokioRwLock<EngineDriver<E>>>,
+    /// State struct to keep track of global state
+    state: Arc<RwLock<State>>,
+    /// Local sequencing source
+    sequencing_src: S,
+    /// Channel to receive the shutdown signal from
+    shutdown_recv: watch::Receiver<bool>,
+}
+
+impl<S: SequencingSource> SequencingDriver<EngineApi, S> {
+    pub fn new(
+        engine_driver: Arc<TokioRwLock<EngineDriver<EngineApi>>>,
+        state: Arc<RwLock<State>>,
+        sequencing_src: S,
+        shutdown_recv: watch::Receiver<bool>,
+    ) -> SequencingDriver<EngineApi, S> {
+        SequencingDriver {
+            engine_driver,
+            state,
+            sequencing_src,
+            shutdown_recv,
+        }
+    }
+
+    /// Shuts down the driver
+    pub async fn shutdown(&self) {
+        process::exit(0);
+    }
+
+    /// Checks for shutdown signal and shuts down if received
+    async fn check_shutdown(&self) {
+        if *self.shutdown_recv.borrow() {
+            self.shutdown().await;
+        }
+    }
+
+    /// Runs the driver
+    pub async fn start(&mut self) -> Result<()> {
+        tracing::trace!("starting sequencing driver, waiting for engine...");
+        self.await_engine_ready().await;
+        tracing::trace!("advancing sequencing driver...");
+        loop {
+            self.check_shutdown().await;
+
+            if let Err(err) = self.advance().await {
+                tracing::error!("fatal error: {:?}", err);
+                self.shutdown().await;
+            }
+        }
+    }
+
+    /// Attempts to advance sequencing forward using attrs received from `sequencing_src`.
+    async fn advance(&mut self) -> Result<()> {
+        let step = {
+            let engine_driver = self.engine_driver.read().await;
+            // Get next attributes from sequencing source.
+            let attrs = self
+                .sequencing_src
+                .get_next_attributes(
+                    &self.state,
+                    &engine_driver.unsafe_head,
+                    &engine_driver.unsafe_epoch,
+                )
+                .await?;
+            // Determine action to take on the next attributes.
+            match attrs {
+                Some(attrs) => Some((
+                    attrs.clone(),
+                    engine_driver.determine_action(attrs.clone()).await?,
+                )),
+                None => None,
+            }
+        };
+        match step {
+            Some((attrs, action)) => {
+                execute_action(
+                    &attrs,
+                    action,
+                    ChainHead::Unsafe,
+                    self.engine_driver.clone(),
+                )
+                .await
+            }
+            None => Ok(()),
+        }
+    }
+
+    async fn await_engine_ready(&self) {
+        while !self.engine_driver.read().await.engine_ready().await {
+            self.check_shutdown().await;
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+}

--- a/src/driver/sequencing/driver.rs
+++ b/src/driver/sequencing/driver.rs
@@ -58,12 +58,12 @@ impl<S: SequencingSource> SequencingDriver<EngineApi, S> {
 
     /// Runs the driver
     pub async fn start(&mut self) -> Result<()> {
-        tracing::trace!("starting sequencing driver, waiting for engine...");
+        tracing::info!("starting sequencing driver; waiting for engine...");
         self.await_engine_ready().await;
-        tracing::trace!("advancing sequencing driver...");
         loop {
             self.check_shutdown().await;
-
+            tracing::info!("advancing sequencing driver...");
+            self.await_engine_ready().await;
             if let Err(err) = self.advance().await {
                 tracing::error!("fatal error: {:?}", err);
                 self.shutdown().await;

--- a/src/specular/config.rs
+++ b/src/specular/config.rs
@@ -1,7 +1,7 @@
 use ethers::types::{Address, H256, U256};
 use eyre::Context;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
 
 use crate::{
     common::{BlockInfo, Epoch},
@@ -42,6 +42,11 @@ struct ChainGenesisInfo {
 }
 
 impl ChainConfig {
+    pub fn is_specular_config(path: &str) -> bool {
+        let file_name = Path::new(path).file_name().unwrap().to_str().unwrap();
+        file_name.starts_with("sp_") && file_name.ends_with(".json")
+    }
+
     pub fn from_specular_json(path: &str) -> Self {
         let file = std::fs::File::open(path)
             .with_context(|| format!("Failed to read chain config from {}", path))

--- a/src/specular/sequencing/config.rs
+++ b/src/specular/sequencing/config.rs
@@ -5,10 +5,10 @@ use crate::config::{Config as MagiConfig, SystemConfig as MagiSystemConfig};
 /// Sequencing policy configuration.
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub l2_chain_id: u64,
     pub max_safe_lag: u64,
     pub max_seq_drift: u64,
     pub blocktime: u64,
+    pub l2_chain_id: u64,
     pub system_config: SystemConfig,
     pub sequencer_private_key: String,
 }
@@ -24,10 +24,10 @@ pub struct SystemConfig {
 impl Config {
     pub fn new(config: &MagiConfig) -> Self {
         Self {
-            l2_chain_id: config.chain.l2_chain_id,
             max_safe_lag: config.local_sequencer.max_safe_lag,
             max_seq_drift: config.chain.max_seq_drift,
             blocktime: config.chain.blocktime,
+            l2_chain_id: config.chain.l2_chain_id,
             system_config: SystemConfig::new(&config.chain.system_config),
             sequencer_private_key: config
                 .local_sequencer

--- a/src/specular/stages/batches.rs
+++ b/src/specular/stages/batches.rs
@@ -12,15 +12,15 @@ use crate::config::Config;
 use crate::derive::stages::batches::Batch;
 use crate::derive::state::State;
 use crate::derive::PurgeableIterator;
+use crate::specular::config::SystemAccounts;
 use ethers::{
     types::Transaction,
     utils::rlp::{Decodable, Rlp},
 };
 
 use super::batcher_transactions::SpecularBatcherTransaction;
-use crate::specular::{
-    common::{SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR},
-    config::SystemAccounts,
+use crate::specular::common::{
+    SetL1OracleValuesInput, SET_L1_ORACLE_VALUES_ABI, SET_L1_ORACLE_VALUES_SELECTOR,
 };
 
 /// The second stage of Specular's derive pipeline.


### PR DESCRIPTION
- Move sequencing functionality into its own coroutine (see: `SequencingDriver`)
- Synchronize via async-compatible `tokio::RwLock` on `engine_driver`
- Expose more `engine_driver` functionality and abstract out functions by whether or not they require `&mut self`. this is necessary to reduce the critical section for write-locking (e.g. shouldn't write-lock while sleeping for 2s in `build_payload`)

todo in future PR: avoid extraneous fork-choice updates (e.g. we can do a single update per control loop iteration)