### PR TITLE
Unblock normal loop from sequencing loop

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -112,8 +112,10 @@ impl Driver<EngineApi> {
         let service = Service::new("0.0.0.0:9876".parse()?, config.chain.l2_chain_id)
             .add_handler(Box::new(block_handler));
 
+        let engine_driver = Arc::new(TokioRwLock::new(engine_driver));
+
         Ok(Self {
-            engine_driver: Arc::new(TokioRwLock::new(engine_driver)),
+            engine_driver,
             pipeline,
             unfinalized_blocks: Vec::new(),
             finalized_l1_block_number: 0,
@@ -196,7 +198,7 @@ impl<E: Engine> Driver<E> {
                 .ok_or(eyre::eyre!("attributes without seq number"))?;
 
             handle_attributes(
-                &next_attributes,
+                next_attributes,
                 ChainHeadType::Safe,
                 self.engine_driver.clone(),
             )

--- a/src/driver/sequencing/driver.rs
+++ b/src/driver/sequencing/driver.rs
@@ -91,7 +91,7 @@ impl<S: SequencingSource> SequencingDriver<EngineApi, S> {
         match step {
             Some((attrs, action)) => {
                 execute_action(
-                    &attrs,
+                    attrs,
                     action,
                     ChainHeadType::Unsafe,
                     self.engine_driver.clone(),


### PR DESCRIPTION
# Core changes
- move the sequencing sleep out of engine driver so the normal loop can acquire locks while sequencing loop is sleeping