### PR TITLE
Set correct heads when starting magi

### DIFF
--- a/src/derive/state.rs
+++ b/src/derive/state.rs
@@ -18,12 +18,12 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(finalized_head: BlockInfo, finalized_epoch: Epoch, config: Arc<Config>) -> Self {
+    pub fn new(safe_head: BlockInfo, safe_epoch: Epoch, config: Arc<Config>) -> Self {
         Self {
             l1_info: BTreeMap::new(),
             l1_hashes: BTreeMap::new(),
-            safe_head: finalized_head,
-            safe_epoch: finalized_epoch,
+            safe_head,
+            safe_epoch,
             current_epoch_num: 0,
             config,
         }

--- a/src/driver/engine_driver.rs
+++ b/src/driver/engine_driver.rs
@@ -16,6 +16,8 @@ use crate::{
     engine::{Engine, EngineApi, ExecutionPayload, ForkchoiceState, PayloadAttributes, Status},
 };
 
+use super::HeadInfo;
+
 pub struct EngineDriver<E: Engine> {
     /// The L2 execution engine
     engine: Arc<E>,
@@ -390,8 +392,9 @@ fn should_skip(block: &Block<Transaction>, attributes: &PayloadAttributes) -> Re
 
 impl EngineDriver<EngineApi> {
     pub fn new(
-        finalized_head: BlockInfo,
-        finalized_epoch: Epoch,
+        finalized_head: HeadInfo,
+        safe_head: HeadInfo,
+        unsafe_head: HeadInfo,
         provider: Provider<Http>,
         config: &Arc<Config>,
     ) -> Result<Self> {
@@ -401,12 +404,12 @@ impl EngineDriver<EngineApi> {
             engine,
             provider,
             blocktime: config.chain.blocktime,
-            unsafe_head: finalized_head,
-            unsafe_epoch: finalized_epoch,
-            safe_head: finalized_head,
-            safe_epoch: finalized_epoch,
-            finalized_head,
-            finalized_epoch,
+            unsafe_head: unsafe_head.l2_block_info,
+            unsafe_epoch: unsafe_head.l1_epoch,
+            safe_head: safe_head.l2_block_info,
+            safe_epoch: safe_head.l1_epoch,
+            finalized_head: finalized_head.l2_block_info,
+            finalized_epoch: finalized_head.l1_epoch,
         })
     }
 }

--- a/src/driver/info.rs
+++ b/src/driver/info.rs
@@ -35,8 +35,12 @@ impl<'a, P: JsonRpcClient> InnerProvider for HeadInfoFetcher<'a, P> {
 pub struct HeadInfoQuery {}
 
 impl HeadInfoQuery {
-    pub async fn get_head_info<P: InnerProvider>(p: &P, config: &Config) -> HeadInfo {
-        p.get_block_with_txs(BlockId::Number(BlockNumber::Finalized))
+    pub async fn get_head_info<P: InnerProvider>(
+        p: &P,
+        config: &Config,
+        block_number: BlockNumber,
+    ) -> HeadInfo {
+        p.get_block_with_txs(BlockId::Number(block_number))
             .await
             .ok()
             .flatten()
@@ -156,7 +160,8 @@ mod tests {
     async fn test_get_head_info_fails() {
         let provider = test_utils::mock_provider(None);
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         assert_eq!(test_utils::default_head_info(), head_info);
     }
 
@@ -164,7 +169,8 @@ mod tests {
     async fn test_get_head_info_empty_block() {
         let provider = test_utils::mock_provider(Some(Block::default()));
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         assert_eq!(test_utils::default_head_info(), head_info);
     }
 
@@ -172,7 +178,8 @@ mod tests {
     async fn test_get_head_info_valid_block() {
         let provider = test_utils::mock_provider(test_utils::valid_block());
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         assert_eq!(test_utils::default_head_info(), head_info);
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -104,7 +104,7 @@ impl Driver<EngineApi> {
         let finalized_seq = finalized_head.sequence_number;
 
         tracing::info!(
-            "starting from head: fianlized {:?}, safe {:?}, latest {:?}",
+            "starting from head: finalized {:?}, safe {:?}, latest {:?}",
             finalized_l2_block.hash,
             safe_head.l2_block_info.hash,
             latest_head.l2_block_info.hash

--- a/src/specular/info.rs
+++ b/src/specular/info.rs
@@ -59,9 +59,13 @@ impl<'a, P: JsonRpcClient> InnerProvider for HeadInfoFetcher<'a, P> {
 pub struct HeadInfoQuery {}
 
 impl HeadInfoQuery {
-    pub async fn get_head_info<P: InnerProvider>(p: &P, config: &Config) -> HeadInfo {
+    pub async fn get_head_info<P: InnerProvider>(
+        p: &P,
+        config: &Config,
+        block_number: BlockNumber,
+    ) -> HeadInfo {
         if let Some(block) = p
-            .get_block_with_txs(BlockId::Number(BlockNumber::Finalized))
+            .get_block_with_txs(BlockId::Number(block_number))
             .await
             .ok()
             .flatten()
@@ -266,7 +270,8 @@ mod tests {
     async fn test_get_head_info_fails() {
         let provider = test_utils::mock_provider(None, None);
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         assert_eq!(test_utils::default_head_info(), head_info);
     }
 
@@ -274,7 +279,8 @@ mod tests {
     async fn test_get_head_info_empty_block() {
         let provider = test_utils::mock_provider(Some(Block::default()), Some(Epoch::default()));
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         assert_eq!(test_utils::default_head_info(), head_info);
     }
 
@@ -285,7 +291,8 @@ mod tests {
             Some(test_utils::default_head_info().l1_epoch),
         );
         let config = test_utils::optimism_config();
-        let head_info = HeadInfoQuery::get_head_info(&provider, &config).await;
+        let head_info =
+            HeadInfoQuery::get_head_info(&provider, &config, BlockNumber::Finalized).await;
         // In Optimism's case their `valid_block` does not contain the AttributeDeposit transaction
         // so their `get_head_info` will fallback to the genesis head.
         // However in our case we get the epoch from the storage, so we can get the correct head info.

--- a/src/specular/info.rs
+++ b/src/specular/info.rs
@@ -70,7 +70,7 @@ impl HeadInfoQuery {
             .ok()
             .flatten()
         {
-            if let Ok(info) = to_specular_head_info(p, block).await {
+            if let Ok(info) = to_specular_head_info(p, config, block).await {
                 return info;
             }
         }
@@ -85,6 +85,7 @@ impl HeadInfoQuery {
 
 async fn to_specular_head_info<P: InnerProvider>(
     p: &P,
+    config: &Config,
     block: Block<Transaction>,
 ) -> Result<HeadInfo> {
     if let Some(tx) = block.transactions.first() {
@@ -107,6 +108,11 @@ async fn to_specular_head_info<P: InnerProvider>(
         )
         .await?
         .to_low_u64_be();
+
+    if epoch_number < config.chain.l1_start_epoch.number {
+        eyre::bail!("L1Oracle is not initialized on L2 yet");
+    }
+
     let epoch_timestamp = p
         .get_storage_at(
             SystemAccounts::default().l1_oracle,


### PR DESCRIPTION
# Core changes
- This pr fetches and sets correct `Finalized`, `Safe`, and `Latest` L2 head when starting magi to allow sequencing to resume on the correct state