### PR TITLE
ChainWatcher Delay

### DIFF
--- a/src/driver/sequencing/driver.rs
+++ b/src/driver/sequencing/driver.rs
@@ -123,7 +123,6 @@ impl<S: SequencingSource, U: JsonRpcClient> SequencingDriver<EngineApi, S, U> {
             }
             None => {
                 tracing::trace!("no payload to build");
-                sleep(Duration::from_secs(1)).await;
                 Ok(())
             }
         }

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, sync::Arc, time::{Duration, SystemTime}};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime},
+    cmp::max
+};
 
 use ethers::{
     providers::{Http, HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient},
@@ -531,7 +536,7 @@ fn start_watcher(
             }
             // TODO make configurable
             let elapsed = now.elapsed().unwrap_or_default();
-            let delay = if elapsed.as_secs() > 2 { 0 } else { 2000 - elapsed.as_millis() };
+            let delay = max(0, 2000 - elapsed.as_millis());
             sleep(Duration::from_millis(delay.try_into().unwrap())).await;
         }
     });

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -1,8 +1,8 @@
 use std::{
+    cmp::max
     collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime},
-    cmp::max
 };
 
 use ethers::{

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -528,6 +528,8 @@ fn start_watcher(
                     err
                 );
             }
+            // TODO make configurable
+            sleep(Duration::from_secs(2)).await;
         }
     });
 

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -529,7 +529,7 @@ fn start_watcher(
                 );
             }
             // TODO make configurable
-            sleep(Duration::from_secs(2)).await;
+            sleep(Duration::from_millis(1750)).await;
         }
     });
 

--- a/src/l1/mod.rs
+++ b/src/l1/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::max
+    cmp::max,
     collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime},


### PR DESCRIPTION
Add a delay to ChainWatcher to reduce L1 calls being made.

TODO: make this configurable